### PR TITLE
ci: Change rule for all branches / PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - 'dev'
-      - 'master'
+      - '*'
+    pull_request:
+      branches:
+        - '*'
 
 jobs:
   build:


### PR DESCRIPTION
Only master / dev branches were running the CI pipeline: this change makes it run for all branches, including pull requests.