### PR TITLE
Add missing API errors

### DIFF
--- a/src/Resend/ErrorType.cs
+++ b/src/Resend/ErrorType.cs
@@ -53,7 +53,7 @@ public enum ErrorType
     /// Invalid `from` field.
     /// </summary>
     /// <remarks>
-    /// Make sure the from field is a valid. The email address needs to follow the
+    /// Make sure the from field is valid. The email address needs to follow the
     /// <code>email@example.com</code> or Name <code>&lt;email@example.com&gt;</code> format.
     /// </remarks>
     [JsonStringValue( "invalid_from_address" )]


### PR DESCRIPTION
Add missing errors from https://resend.com/docs/api-reference/errors#invalid-api-key into ErrorType enum.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Extended ErrorType to include missing Resend API errors, aligning with Resend docs and ensuring correct mapping and easier error handling.

- **New Features**
  - Added mappings: invalid_api_key, method_not_allowed, invalid_from_address, invalid_access, invalid_parameter, invalid_region, monthly_quota_exceeded, internal_server_error.

<!-- End of auto-generated description by cubic. -->

