### PR TITLE
feat: add webhooks APIs

### DIFF
--- a/examples/WebhookWorkflow/Program.cs
+++ b/examples/WebhookWorkflow/Program.cs
@@ -1,0 +1,109 @@
+using Resend;
+using System.Text.Json;
+
+var apiKey = Environment.GetEnvironmentVariable( "RESEND_API_KEY" );
+
+if ( apiKey == null )
+{
+    Console.Error.WriteLine( "Error: RESEND_API_KEY environment variable is not set" );
+    return 1;
+}
+
+var options = new ResendClientOptions()
+{
+    ApiToken = apiKey,
+};
+
+var resend = ResendClient.Create( options );
+var jsonOptions = new JsonSerializerOptions { WriteIndented = true };
+
+try
+{
+    Console.WriteLine( "==> Creating webhook..." );
+    var createResponse = await resend.WebhookAddAsync( new WebhookAddData()
+    {
+        EndpointUrl = "https://example.com/webhook",
+        Events = new List<WebhookEventType>
+        {
+            WebhookEventType.EmailSent,
+            WebhookEventType.EmailDelivered,
+            WebhookEventType.EmailBounced
+        }
+    } );
+
+    Console.WriteLine( JsonSerializer.Serialize( createResponse.Content, jsonOptions ) );
+    var webhookId = createResponse.Content.Id;
+    Console.WriteLine();
+
+    await Task.Delay( 5000 );
+
+    Console.WriteLine( "==> Getting webhook by ID..." );
+    var getResponse = await resend.WebhookRetrieveAsync( webhookId );
+    Console.WriteLine( JsonSerializer.Serialize( getResponse.Content, jsonOptions ) );
+    Console.WriteLine();
+
+    await Task.Delay( 5000 );
+
+    Console.WriteLine( "==> Updating webhook..." );
+    var updateResponse = await resend.WebhookUpdateAsync( webhookId, new WebhookUpdateData()
+    {
+        EndpointUrl = "https://example.com/webhook-updated",
+        Events = new List<WebhookEventType>
+        {
+            WebhookEventType.EmailSent,
+            WebhookEventType.EmailDelivered,
+            WebhookEventType.EmailBounced,
+            WebhookEventType.EmailOpened,
+            WebhookEventType.EmailClicked
+        },
+        Status = WebhookStatus.Enabled
+    } );
+
+    Console.WriteLine( "Update successful" );
+    Console.WriteLine();
+
+    await Task.Delay( 5000 );
+
+    Console.WriteLine( "==> Getting updated webhook..." );
+    var getUpdatedResponse = await resend.WebhookRetrieveAsync( webhookId );
+    Console.WriteLine( JsonSerializer.Serialize( getUpdatedResponse.Content, jsonOptions ) );
+    Console.WriteLine();
+
+    await Task.Delay( 5000 );
+
+    Console.WriteLine( "==> Listing all webhooks..." );
+    var listResponse = await resend.WebhookListAsync( new PaginatedQuery() { Limit = 10 } );
+    Console.WriteLine( JsonSerializer.Serialize( listResponse.Content, jsonOptions ) );
+    Console.WriteLine();
+
+    await Task.Delay( 5000 );
+
+    Console.WriteLine( "==> Deleting webhook..." );
+    var deleteResponse = await resend.WebhookDeleteAsync( webhookId );
+    Console.WriteLine( "Delete successful" );
+    Console.WriteLine();
+
+    await Task.Delay( 5000 );
+
+    Console.WriteLine( "==> Verifying deletion by listing webhooks..." );
+    var verifyResponse = await resend.WebhookListAsync();
+    Console.WriteLine( JsonSerializer.Serialize( verifyResponse.Content, jsonOptions ) );
+    Console.WriteLine();
+
+    Console.WriteLine( "Workflow completed successfully!" );
+    return 0;
+}
+catch ( ResendException ex )
+{
+    Console.Error.WriteLine( $"Error: {ex.ErrorType} - {ex.Message}" );
+    if ( ex.InnerException != null )
+    {
+        Console.Error.WriteLine( $"Inner: {ex.InnerException.Message}" );
+    }
+    return 1;
+}
+catch ( Exception ex )
+{
+    Console.Error.WriteLine( $"Unexpected error: {ex.Message}" );
+    return 1;
+}

--- a/examples/WebhookWorkflow/README.md
+++ b/examples/WebhookWorkflow/README.md
@@ -1,0 +1,42 @@
+# Webhook Workflow Example
+
+This example demonstrates a complete webhook lifecycle using the Resend .NET SDK:
+
+1. Create a webhook
+2. Retrieve the webhook by ID
+3. Update the webhook (endpoint, events, and status)
+4. List all webhooks
+5. Delete the webhook
+6. Verify deletion
+
+## Prerequisites
+
+- .NET 8.0 SDK
+- Resend API key
+
+## Running the Example
+
+1. Set your Resend API key as an environment variable:
+
+```bash
+export RESEND_API_KEY=re_your_api_key_here
+```
+
+2. Run the example:
+
+```bash
+cd examples/WebhookWorkflow
+dotnet run
+```
+
+## Output
+
+The script will output JSON-formatted responses from each API call, showing:
+- The created webhook with its ID and signing secret
+- The retrieved webhook details
+- The list of all webhooks
+- Confirmation of deletion
+
+## Note
+
+This example uses a test endpoint URL (`https://example.com/webhook`). In production, you would use your actual webhook endpoint that can receive and process webhook events.

--- a/examples/WebhookWorkflow/WebhookWorkflow.csproj
+++ b/examples/WebhookWorkflow/WebhookWorkflow.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Resend\Resend.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -1,4 +1,6 @@
-﻿namespace Resend;
+﻿using Resend.Payloads;
+
+namespace Resend;
 
 /// <summary>
 /// Resend client.
@@ -622,4 +624,87 @@ public interface IResend
     /// <param name="cancellationToken">Cancelation token.</param>
     /// <returns>Response.</returns>
     Task<ResendResponse> BroadcastDeleteAsync( Guid broadcastId, CancellationToken cancellationToken = default );
+
+
+    /// <summary>
+    /// Create a webhook.
+    /// </summary>
+    /// <param name="data">
+    /// Webhook data.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Cancellation token.
+    /// </param>
+    /// <returns>
+    /// Webhook identifier and signing secret.
+    /// </returns>
+    /// <see href="https://resend.com/docs/api-reference/webhooks/create-webhook"/>
+    Task<ResendResponse<WebhookAddResponse>> WebhookAddAsync( WebhookAddData data, CancellationToken cancellationToken = default );
+
+
+    /// <summary>
+    /// Retrieves a webhook.
+    /// </summary>
+    /// <param name="webhookId">
+    /// Webhook identifier.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Cancellation token.
+    /// </param>
+    /// <returns>
+    /// Webhook.
+    /// </returns>
+    /// <see href="https://resend.com/docs/api-reference/webhooks/get-webhook"/>
+    Task<ResendResponse<Webhook>> WebhookRetrieveAsync( Guid webhookId, CancellationToken cancellationToken = default );
+
+
+    /// <summary>
+    /// Retrieve a list of webhooks.
+    /// </summary>
+    /// <param name="query">
+    /// Pagination query.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Cancellation token.
+    /// </param>
+    /// <returns>
+    /// List of webhooks.
+    /// </returns>
+    /// <see href="https://resend.com/docs/api-reference/webhooks/list-webhooks"/>
+    Task<ResendResponse<PaginatedResult<Webhook>>> WebhookListAsync( PaginatedQuery? query = null, CancellationToken cancellationToken = default );
+
+
+    /// <summary>
+    /// Update an existing webhook.
+    /// </summary>
+    /// <param name="webhookId">
+    /// Webhook identifier.
+    /// </param>
+    /// <param name="data">
+    /// Updated webhook information.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Cancellation token.
+    /// </param>
+    /// <returns>
+    /// Task.
+    /// </returns>
+    /// <see href="https://resend.com/docs/api-reference/webhooks/update-webhook"/>
+    Task<ResendResponse> WebhookUpdateAsync( Guid webhookId, WebhookUpdateData data, CancellationToken cancellationToken = default );
+
+
+    /// <summary>
+    /// Remove an existing webhook.
+    /// </summary>
+    /// <param name="webhookId">
+    /// Webhook identifier.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Cancellation token.
+    /// </param>
+    /// <returns>
+    /// Task.
+    /// </returns>
+    /// <see href="https://resend.com/docs/api-reference/webhooks/delete-webhook"/>
+    Task<ResendResponse> WebhookDeleteAsync( Guid webhookId, CancellationToken cancellationToken = default );
 }

--- a/src/Resend/Payloads/WebhookAddResponse.cs
+++ b/src/Resend/Payloads/WebhookAddResponse.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Resend.Payloads;
+
+public class WebhookAddResponse
+{
+    [JsonPropertyName( "object" )]
+    public string Object { get; set; } = default!;
+
+    [JsonPropertyName( "id" )]
+    public Guid Id { get; set; }
+
+    [JsonPropertyName( "signing_secret" )]
+    public string SigningSecret { get; set; } = default!;
+}

--- a/src/Resend/Payloads/WebhookRemoveResponse.cs
+++ b/src/Resend/Payloads/WebhookRemoveResponse.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Resend.Payloads;
+
+public class WebhookRemoveResponse
+{
+    [JsonPropertyName( "object" )]
+    public string Object { get; set; } = default!;
+
+    [JsonPropertyName( "id" )]
+    public Guid Id { get; set; }
+
+    [JsonPropertyName( "deleted" )]
+    public bool Deleted { get; set; }
+}

--- a/src/Resend/ResendClient.cs
+++ b/src/Resend/ResendClient.cs
@@ -324,12 +324,72 @@ public class ResendClient : IResend
 
 
     /// <inheritdoc />
-    public Task<ResendResponse<List<Webhook>>> WebhookListAsync( CancellationToken cancellationToken = default )
+    public Task<ResendResponse<WebhookAddResponse>> WebhookAddAsync( WebhookAddData data, CancellationToken cancellationToken = default )
     {
         var path = $"/webhooks";
+        var req = new HttpRequestMessage( HttpMethod.Post, path );
+        req.Content = JsonContent.Create( data );
+
+        return Execute<WebhookAddResponse, WebhookAddResponse>( req, ( x ) => x, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
+    public Task<ResendResponse<Webhook>> WebhookRetrieveAsync( Guid webhookId, CancellationToken cancellationToken = default )
+    {
+        var path = $"/webhooks/{webhookId}";
         var req = new HttpRequestMessage( HttpMethod.Get, path );
 
-        return Execute<ListOf<Webhook>, List<Webhook>>( req, ( x ) => x.Data, cancellationToken );
+        return Execute<Webhook, Webhook>( req, ( x ) => x, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
+    public Task<ResendResponse<PaginatedResult<Webhook>>> WebhookListAsync( PaginatedQuery? query = null, CancellationToken cancellationToken = default )
+    {
+        var baseUrl = "/webhooks";
+        var url = baseUrl;
+
+        if ( query != null )
+        {
+            var qs = new Dictionary<string, string?>();
+
+            if ( query.Limit.HasValue == true )
+                qs.Add( "limit", query.Limit.Value.ToString() );
+
+            if ( query.Before != null )
+                qs.Add( "before", query.Before );
+
+            if ( query.After != null )
+                qs.Add( "after", query.After );
+
+            url = QueryHelpers.AddQueryString( baseUrl, qs );
+        }
+
+        var req = new HttpRequestMessage( HttpMethod.Get, url );
+
+        return Execute<PaginatedResult<Webhook>, PaginatedResult<Webhook>>( req, ( x ) => x, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
+    public Task<ResendResponse> WebhookUpdateAsync( Guid webhookId, WebhookUpdateData data, CancellationToken cancellationToken = default )
+    {
+        var path = $"/webhooks/{webhookId}";
+        var req = new HttpRequestMessage( HttpMethod.Patch, path );
+        req.Content = JsonContent.Create( data );
+
+        return Execute( req, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
+    public Task<ResendResponse> WebhookDeleteAsync( Guid webhookId, CancellationToken cancellationToken = default )
+    {
+        var path = $"/webhooks/{webhookId}";
+        var req = new HttpRequestMessage( HttpMethod.Delete, path );
+
+        return Execute( req, cancellationToken );
     }
 
 

--- a/src/Resend/Webhook.cs
+++ b/src/Resend/Webhook.cs
@@ -30,7 +30,7 @@ public class Webhook
 
     /// <summary />
     [JsonPropertyName( "events" )]
-    public List<WebhookEventType> Events { get; set; } = default!;
+    public List<WebhookEventType>? Events { get; set; }
 
     /// <summary />
     /// <remarks>

--- a/src/Resend/WebhookAddData.cs
+++ b/src/Resend/WebhookAddData.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+public class WebhookAddData
+{
+    [JsonPropertyName( "endpoint" )]
+    public string EndpointUrl { get; set; } = default!;
+
+    [JsonPropertyName( "events" )]
+    public List<WebhookEventType> Events { get; set; } = default!;
+}

--- a/src/Resend/WebhookEventType.cs
+++ b/src/Resend/WebhookEventType.cs
@@ -51,10 +51,22 @@ public enum WebhookEventType
     EmailClicked,
 
     /// <summary>
-    /// The recipient’s opened the email.
+    /// The recipient's opened the email.
     /// </summary>
     [JsonStringValue( "email.opened" )]
     EmailOpened,
+
+    /// <summary>
+    /// An inbound email was received.
+    /// </summary>
+    [JsonStringValue( "email.received" )]
+    EmailReceived,
+
+    /// <summary>
+    /// The email failed to send.
+    /// </summary>
+    [JsonStringValue( "email.failed" )]
+    EmailFailed,
 
 
     /// <summary>

--- a/src/Resend/WebhookUpdateData.cs
+++ b/src/Resend/WebhookUpdateData.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+public class WebhookUpdateData
+{
+    [JsonPropertyName( "endpoint" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? EndpointUrl { get; set; }
+
+    [JsonPropertyName( "events" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public List<WebhookEventType>? Events { get; set; }
+
+    [JsonPropertyName( "status" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public WebhookStatus? Status { get; set; }
+}

--- a/tests/Resend.Tests/ResendClientTests.cs
+++ b/tests/Resend.Tests/ResendClientTests.cs
@@ -452,4 +452,82 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
 
         Assert.NotNull( resp );
     }
+
+
+    /// <summary/>
+    [Fact]
+    public async Task WebhookAdd()
+    {
+        var req = new WebhookAddData()
+        {
+            EndpointUrl = "https://example.com/webhook",
+            Events = new List<WebhookEventType>()
+            {
+                WebhookEventType.EmailSent,
+                WebhookEventType.EmailDelivered,
+            },
+        };
+
+        var resp = await _resend.WebhookAddAsync( req );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotEqual( Guid.Empty, resp.Content.Id );
+        Assert.NotNull( resp.Content.SigningSecret );
+    }
+
+
+    /// <summary/>
+    [Fact]
+    public async Task WebhookRetrieve()
+    {
+        var resp = await _resend.WebhookRetrieveAsync( Guid.NewGuid() );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.NotEqual( Guid.Empty, resp.Content.Id );
+    }
+
+
+    /// <summary/>
+    [Fact]
+    public async Task WebhookList()
+    {
+        var resp = await _resend.WebhookListAsync( new PaginatedQuery() { Limit = 10 } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.NotNull( resp.Content.Data );
+        Assert.Equal( 2, resp.Content.Data.Count );
+    }
+
+
+    /// <summary/>
+    [Fact]
+    public async Task WebhookUpdate()
+    {
+        var req = new WebhookUpdateData()
+        {
+            EndpointUrl = "https://example.com/webhook-updated",
+            Status = WebhookStatus.Enabled,
+        };
+
+        var resp = await _resend.WebhookUpdateAsync( Guid.NewGuid(), req );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+    }
+
+
+    /// <summary/>
+    [Fact]
+    public async Task WebhookDelete()
+    {
+        var resp = await _resend.WebhookDeleteAsync( Guid.NewGuid() );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+    }
 }

--- a/tools/Resend.ApiServer/Controllers/WebhookController.cs
+++ b/tools/Resend.ApiServer/Controllers/WebhookController.cs
@@ -3,40 +3,111 @@ using Resend.Payloads;
 
 namespace Resend.ApiServer.Controllers;
 
-/// <summary />
 [ApiController]
 public class WebhookController : ControllerBase
 {
     private readonly ILogger<WebhookController> _logger;
 
 
-    /// <summary />
     public WebhookController( ILogger<WebhookController> logger )
     {
         _logger = logger;
     }
 
 
-    /// <summary />
+    [HttpPost]
+    [Route( "webhooks" )]
+    public WebhookAddResponse WebhookAdd( [FromBody] WebhookAddData data )
+    {
+        _logger.LogDebug( "WebhookAdd" );
+
+        return new WebhookAddResponse()
+        {
+            Object = "webhook",
+            Id = Guid.NewGuid(),
+            SigningSecret = "whsec_test_secret_12345",
+        };
+    }
+
+
+    [HttpGet]
+    [Route( "webhooks/{webhookId}" )]
+    public Webhook WebhookRetrieve( Guid webhookId )
+    {
+        _logger.LogDebug( "WebhookRetrieve" );
+
+        return new Webhook()
+        {
+            Id = webhookId,
+            EndpointUrl = "https://example.com/webhook",
+            MomentCreated = DateTime.UtcNow,
+            Status = WebhookStatus.Enabled,
+            Events = new List<WebhookEventType>()
+            {
+                WebhookEventType.EmailSent,
+                WebhookEventType.EmailDelivered,
+            },
+            SecretKey = "whsec_test_secret_12345",
+            SvixEndpointId = "ep_test123",
+        };
+    }
+
+
     [HttpGet]
     [Route( "webhooks" )]
-    public ListOf<Webhook> WebhookList()
+    public PaginatedResult<Webhook> WebhookList()
     {
         _logger.LogDebug( "WebhookList" );
 
-        return new ListOf<Webhook>()
+        return new PaginatedResult<Webhook>()
         {
+            HasMore = false,
             Data = new List<Webhook>()
             {
                 new Webhook()
                 {
                     Id = Guid.NewGuid(),
+                    EndpointUrl = "https://example.com/webhook1",
+                    MomentCreated = DateTime.UtcNow,
+                    Status = WebhookStatus.Enabled,
+                    Events = new List<WebhookEventType>()
+                    {
+                        WebhookEventType.EmailSent,
+                    },
                 },
                 new Webhook()
                 {
                     Id = Guid.NewGuid(),
+                    EndpointUrl = "https://example.com/webhook2",
+                    MomentCreated = DateTime.UtcNow,
+                    Status = WebhookStatus.Disabled,
+                    Events = new List<WebhookEventType>()
+                    {
+                        WebhookEventType.EmailDelivered,
+                        WebhookEventType.EmailBounced,
+                    },
                 }
             },
         };
+    }
+
+
+    [HttpPatch]
+    [Route( "webhooks/{webhookId}" )]
+    public ActionResult WebhookUpdate( [FromRoute] Guid webhookId, [FromBody] WebhookUpdateData data )
+    {
+        _logger.LogDebug( "WebhookUpdate" );
+
+        return Ok();
+    }
+
+
+    [HttpDelete]
+    [Route( "webhooks/{webhookId}" )]
+    public ActionResult WebhookDelete( [FromRoute] Guid webhookId )
+    {
+        _logger.LogDebug( "WebhookDelete" );
+
+        return Ok();
     }
 }


### PR DESCRIPTION
This adds the Webhook APIs:

* Creating a webhook
* Getting a single webhook
* Listing webhooks
* Updating a webhook
* Deleting a webhook

I also added tests and an end-to-end example that I ran to check if it was working end-to-end.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Webhooks API to the SDK for end-to-end management, with pagination support.

- **New Features**
  - Client methods: WebhookAddAsync, WebhookRetrieveAsync, WebhookListAsync(PaginatedQuery), WebhookUpdateAsync, WebhookDeleteAsync.
  - Models: WebhookAddData, WebhookUpdateData, WebhookAddResponse, WebhookRemoveResponse; added EmailReceived and EmailFailed event types.
  - Example workflow in examples/WebhookWorkflow and unit tests covering all endpoints.

- **Migration**
  - WebhookListAsync now returns PaginatedResult<Webhook> and accepts PaginatedQuery; update callers to read Content.Data and use cursor fields.
  - Webhook.Events is now nullable; add null checks when accessing Events.

<sup>Written for commit 6c181f2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

