### PR TITLE
Fix XML documentation warnings

### DIFF
--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -756,7 +756,7 @@ public interface IResend
     /// <summary>
     /// Create a topic.
     /// </summary>
-    /// <param name="segment">Topic data.</param>
+    /// <param name="topic">Topic data.</param>
     /// <param name="cancellationToken">Cancelation token.</param>
     /// <returns>Topic identifier.</returns>
     Task<ResendResponse<Guid>> TopicCreateAsync( TopicData topic, CancellationToken cancellationToken = default );
@@ -781,7 +781,7 @@ public interface IResend
     /// <summary>
     /// Deletes a topic.
     /// </summary>
-    /// <param name="segmentId">Topic identifier.</param>
+    /// <param name="topicId">Topic identifier.</param>
     /// <param name="cancellationToken">Cancelation token.</param>
     /// <returns>Response.</returns>
     Task<ResendResponse> TopicDeleteAsync( Guid topicId, CancellationToken cancellationToken = default );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed XML documentation parameter names in IResend topic methods to match the code, removing warnings and improving IntelliSense.

- **Bug Fixes**
  - Updated <param> from segment to topic in TopicCreateAsync.
  - Updated <param> from segmentId to topicId in TopicDeleteAsync.

<sup>Written for commit 4e7edb5bbb4aea3a12fdc7dc2881fadb305ab608. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

