### PR TITLE
Remove invalid WebhookListAsync method

### DIFF
--- a/src/Resend/ResendClient.cs
+++ b/src/Resend/ResendClient.cs
@@ -323,16 +323,6 @@ public partial class ResendClient : IResend
     }
 
 
-    /// <inheritdoc />
-    public Task<ResendResponse<List<Webhook>>> WebhookListAsync( CancellationToken cancellationToken = default )
-    {
-        var path = $"/webhooks";
-        var req = new HttpRequestMessage( HttpMethod.Get, path );
-
-        return Execute<ListOf<Webhook>, List<Webhook>>( req, ( x ) => x.Data, cancellationToken );
-    }
-
-
     /// <inheritdoc/>
     public Task<ResendResponse<Guid>> AudienceAddAsync( string name, CancellationToken cancellationToken = default )
     {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed WebhookListAsync from ResendClient because the endpoint is invalid, preventing incorrect calls and reducing confusion. Aligns with Linear #84 to keep the public API accurate.

<sup>Written for commit e3b80ff83a5cc4b3b0eb12e3822a5caaad4a590d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

