### PR TITLE
Add string overloads for Template methods

### DIFF
--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -709,6 +709,14 @@ public interface IResend
     Task<ResendResponse<Template>> TemplateRetrieveAsync( Guid templateId, CancellationToken cancellationToken = default );
 
     /// <summary>
+    /// Retrieve a template, by alias.
+    /// </summary>
+    /// <param name="templateAlias">Template alias.</param>
+    /// <param name="cancellationToken">Cancelation token.</param>
+    /// <returns>Template.</returns>
+    Task<ResendResponse<Template>> TemplateRetrieveAsync( string templateAlias, CancellationToken cancellationToken = default );
+
+    /// <summary>
     /// Updates a template.
     /// </summary>
     /// <param name="templateId">Template identifier.</param>
@@ -716,6 +724,15 @@ public interface IResend
     /// <param name="cancellationToken">Cancelation token.</param>
     /// <returns>Response.</returns>
     Task<ResendResponse> TemplateUpdateAsync( Guid templateId, TemplateData template, CancellationToken cancellationToken = default );
+
+    /// <summary>
+    /// Updates a template, by alias.
+    /// </summary>
+    /// <param name="templateAlias">Template alias.</param>
+    /// <param name="template">Template data.</param>
+    /// <param name="cancellationToken">Cancelation token.</param>
+    /// <returns>Response.</returns>
+    Task<ResendResponse> TemplateUpdateAsync( string templateAlias, TemplateData template, CancellationToken cancellationToken = default );
 
     /// <summary>
     /// Deletes a template.
@@ -726,6 +743,14 @@ public interface IResend
     Task<ResendResponse> TemplateDeleteAsync( Guid templateId, CancellationToken cancellationToken = default );
 
     /// <summary>
+    /// Deletes a template, by alias.
+    /// </summary>
+    /// <param name="templateAlias">Template alias.</param>
+    /// <param name="cancellationToken">Cancelation token.</param>
+    /// <returns>Response.</returns>
+    Task<ResendResponse> TemplateDeleteAsync( string templateAlias, CancellationToken cancellationToken = default );
+
+    /// <summary>
     /// Publishes a template.
     /// </summary>
     /// <param name="templateId">Template identifier.</param>
@@ -734,12 +759,28 @@ public interface IResend
     Task<ResendResponse> TemplatePublishAsync( Guid templateId, CancellationToken cancellationToken = default );
 
     /// <summary>
+    /// Publishes a template, by alias.
+    /// </summary>
+    /// <param name="templateAlias">Template alias.</param>
+    /// <param name="cancellationToken">Cancelation token.</param>
+    /// <returns>Response.</returns>
+    Task<ResendResponse> TemplatePublishAsync( string templateAlias, CancellationToken cancellationToken = default );
+
+    /// <summary>
     /// Duplicates a template.
     /// </summary>
     /// <param name="templateId">Template identifier.</param>
     /// <param name="cancellationToken">Cancelation token.</param>
     /// <returns>Identifier of newly created duplicate.</returns>
     Task<ResendResponse<Guid>> TemplateDuplicateAsync( Guid templateId, CancellationToken cancellationToken = default );
+
+    /// <summary>
+    /// Duplicates a template, by alias.
+    /// </summary>
+    /// <param name="templateAlias">Template alias.</param>
+    /// <param name="cancellationToken">Cancelation token.</param>
+    /// <returns>Identifier of newly created duplicate.</returns>
+    Task<ResendResponse<Guid>> TemplateDuplicateAsync( string templateAlias, CancellationToken cancellationToken = default );
 
     #endregion
 

--- a/src/Resend/ResendClient.Templates.cs
+++ b/src/Resend/ResendClient.Templates.cs
@@ -55,9 +55,29 @@ public partial class ResendClient
 
 
     /// <inheritdoc />
+    public Task<ResendResponse<Template>> TemplateRetrieveAsync( string templateAlias, CancellationToken cancellationToken = default )
+    {
+        var path = $"/templates/{templateAlias}";
+        var req = new HttpRequestMessage( HttpMethod.Get, path );
+
+        return Execute<Template, Template>( req, ( x ) => x, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
     public Task<ResendResponse> TemplateUpdateAsync( Guid templateId, TemplateData template, CancellationToken cancellationToken = default )
     {
         var req = new HttpRequestMessage( HttpMethod.Patch, $"/templates/{templateId}" );
+        req.Content = JsonContent.Create( template );
+
+        return Execute( req, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
+    public Task<ResendResponse> TemplateUpdateAsync( string templateAlias, TemplateData template, CancellationToken cancellationToken = default )
+    {
+        var req = new HttpRequestMessage( HttpMethod.Patch, $"/templates/{templateAlias}" );
         req.Content = JsonContent.Create( template );
 
         return Execute( req, cancellationToken );
@@ -74,6 +94,15 @@ public partial class ResendClient
 
 
     /// <inheritdoc />
+    public Task<ResendResponse> TemplateDeleteAsync( string templateAlias, CancellationToken cancellationToken = default )
+    {
+        var req = new HttpRequestMessage( HttpMethod.Delete, $"/templates/{templateAlias}" );
+
+        return Execute( req, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
     public Task<ResendResponse> TemplatePublishAsync( Guid templateId, CancellationToken cancellationToken = default )
     {
         var req = new HttpRequestMessage( HttpMethod.Post, $"/templates/{templateId}/publish" );
@@ -83,9 +112,27 @@ public partial class ResendClient
 
 
     /// <inheritdoc />
+    public Task<ResendResponse> TemplatePublishAsync( string templateAlias, CancellationToken cancellationToken = default )
+    {
+        var req = new HttpRequestMessage( HttpMethod.Post, $"/templates/{templateAlias}/publish" );
+
+        return Execute( req, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
     public Task<ResendResponse<Guid>> TemplateDuplicateAsync( Guid templateId, CancellationToken cancellationToken = default )
     {
         var req = new HttpRequestMessage( HttpMethod.Post, $"/templates/{templateId}/duplicate" );
+
+        return Execute<ObjectId, Guid>( req, x => x.Id, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
+    public Task<ResendResponse<Guid>> TemplateDuplicateAsync( string templateAlias, CancellationToken cancellationToken = default )
+    {
+        var req = new HttpRequestMessage( HttpMethod.Post, $"/templates/{templateAlias}/duplicate" );
 
         return Execute<ObjectId, Guid>( req, x => x.Id, cancellationToken );
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add string overloads for Template methods to support using template aliases in addition to GUIDs. This lets clients retrieve, update, delete, publish, and duplicate templates by alias.

- **New Features**
  - TemplateRetrieveAsync(string templateAlias)
  - TemplateUpdateAsync(string templateAlias, TemplateData template)
  - TemplateDeleteAsync(string templateAlias)
  - TemplatePublishAsync(string templateAlias)
  - TemplateDuplicateAsync(string templateAlias)

<sup>Written for commit 0440ae59fbbca17706c26acd9fffb6e4bc974144. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

