### PR TITLE
Update Contacts, Deprecate Audiences

### DIFF
--- a/src/Resend.Webhooks/ContactEventData.cs
+++ b/src/Resend.Webhooks/ContactEventData.cs
@@ -10,8 +10,9 @@ public class ContactEventData : IWebhookData
     public Guid ContactId { get; set; }
 
     /// <summary />
-    [JsonPropertyName( "segment_id" )]
-    public Guid SegmentId { get; set; }
+    [JsonPropertyName( "segment_ids" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public List<Guid>? SegmentIds { get; set; }
 
     /// <summary />
     [JsonPropertyName( "created_at" )]

--- a/src/Resend.Webhooks/ContactEventData.cs
+++ b/src/Resend.Webhooks/ContactEventData.cs
@@ -10,8 +10,8 @@ public class ContactEventData : IWebhookData
     public Guid ContactId { get; set; }
 
     /// <summary />
-    [JsonPropertyName( "audience_id" )]
-    public Guid AudienceId { get; set; }
+    [JsonPropertyName( "segment_id" )]
+    public Guid SegmentId { get; set; }
 
     /// <summary />
     [JsonPropertyName( "created_at" )]

--- a/src/Resend/Broadcast.cs
+++ b/src/Resend/Broadcast.cs
@@ -19,10 +19,10 @@ public class Broadcast
     public string? DisplayName { get; set; }
 
     /// <summary>
-    /// Audience identifier.
+    /// Segment identifier.
     /// </summary>
-    [JsonPropertyName( "audience_id" )]
-    public Guid AudienceId { get; set; }
+    [JsonPropertyName( "segment_id" )]
+    public Guid SegmentId { get; set; }
 
     /// <summary>
     /// From.

--- a/src/Resend/BroadcastData.cs
+++ b/src/Resend/BroadcastData.cs
@@ -13,10 +13,10 @@ public class BroadcastData
     public string? DisplayName { get; set; }
 
     /// <summary>
-    /// Audience identifier.
+    /// Segment identifier.
     /// </summary>
-    [JsonPropertyName( "audience_id" )]
-    public Guid AudienceId { get; set; }
+    [JsonPropertyName( "segment_id" )]
+    public Guid SegmentId { get; set; }
 
     /// <summary>
     /// Sender email address.

--- a/src/Resend/BroadcastUpdateData.cs
+++ b/src/Resend/BroadcastUpdateData.cs
@@ -13,11 +13,11 @@ public class BroadcastUpdateData
     public string? DisplayName { get; set; }
 
     /// <summary>
-    /// Audience identifier.
+    /// Segment identifier.
     /// </summary>
-    [JsonPropertyName( "audience_id" )]
+    [JsonPropertyName( "segment_id" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-    public Guid? AudienceId { get; set; }
+    public Guid? SegmentId { get; set; }
 
     /// <summary>
     /// Sender email address.

--- a/src/Resend/Contact.cs
+++ b/src/Resend/Contact.cs
@@ -46,4 +46,11 @@ public class Contact
     [JsonPropertyName( "unsubscribed" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
     public bool? IsUnsubscribed { get; set; }
+
+    /// <summary>
+    /// Key/value custom properties for the contact.
+    /// </summary>
+    [JsonPropertyName( "properties" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public Dictionary<string,string>? Properties { get; set; }
 }

--- a/src/Resend/ContactData.cs
+++ b/src/Resend/ContactData.cs
@@ -36,4 +36,11 @@ public class ContactData
     [JsonPropertyName( "unsubscribed" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
     public bool? IsUnsubscribed { get; set; }
+
+    /// <summary>
+    /// Key/value custom properties for the contact.
+    /// </summary>
+    [JsonPropertyName( "properties" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public Dictionary<string, string>? Properties { get; set; }
 }

--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -368,6 +368,7 @@ public interface IResend
     /// Task.
     /// </returns>
     /// <see href="https://resend.com/docs/api-reference/audiences/create-audience" />
+    [Obsolete( "Use Segments instead" )]
     Task<ResendResponse<Guid>> AudienceAddAsync( string name, CancellationToken cancellationToken = default );
 
     /// <summary>
@@ -383,6 +384,7 @@ public interface IResend
     /// List of Audience.
     /// </returns>
     /// <see href="https://resend.com/docs/api-reference/audiences/get-audience" />
+    [Obsolete( "Use Segments instead" )]
     Task<ResendResponse<Audience>> AudienceRetrieveAsync( Guid audienceId, CancellationToken cancellationToken = default );
 
     /// <summary>
@@ -398,6 +400,7 @@ public interface IResend
     /// Task.
     /// </returns>
     /// <see href="https://resend.com/docs/api-reference/audiences/delete-audience" />
+    [Obsolete( "Use Segments instead" )]
     Task<ResendResponse> AudienceDeleteAsync( Guid audienceId, CancellationToken cancellationToken = default );
 
     /// <summary>
@@ -410,6 +413,7 @@ public interface IResend
     /// A list of Audience.
     /// </returns>
     /// <see href="https://resend.com/docs/api-reference/audiences/list-audiences" />
+    [Obsolete( "Use Segments instead" )]
     Task<ResendResponse<List<Audience>>> AudienceListAsync( CancellationToken cancellationToken = default );
 
     #endregion
@@ -417,11 +421,8 @@ public interface IResend
     #region Contacts
 
     /// <summary>
-    /// Create a contact inside an audience.
+    /// Create a contact.
     /// </summary>
-    /// /// <param name="audienceId">
-    /// Audience identifier.
-    /// </param>
     /// <param name="data">
     /// Contact data.
     /// </param>
@@ -432,14 +433,11 @@ public interface IResend
     /// Contact Id. 
     /// </returns>
     /// <see href="https://resend.com/docs/api-reference/contacts/create-contact" />
-    Task<ResendResponse<Guid>> ContactAddAsync( Guid audienceId, ContactData data, CancellationToken cancellationToken = default );
+    Task<ResendResponse<Guid>> ContactAddAsync( ContactData data, CancellationToken cancellationToken = default );
 
     /// <summary>
-    /// Retrieve a single contact from an audience.
+    /// Retrieve a contact.
     /// </summary>
-    /// <param name="audienceId">
-    /// Audience identifier.
-    /// </param>
     /// <param name="contactId">
     /// Contact identifier.
     /// </param>
@@ -450,14 +448,11 @@ public interface IResend
     /// A Contact.
     /// </returns>
     /// <see href="https://resend.com/docs/api-reference/contacts/get-contact" />
-    Task<ResendResponse<Contact>> ContactRetrieveAsync( Guid audienceId, Guid contactId, CancellationToken cancellationToken = default );
+    Task<ResendResponse<Contact>> ContactRetrieveAsync( Guid contactId, CancellationToken cancellationToken = default );
 
     /// <summary>
     /// Retrieve a single contact from an audience using email address.
     /// </summary>
-    /// <param name="audienceId">
-    /// Audience identifier.
-    /// </param>
     /// <param name="email">
     /// Contact email.
     /// </param>
@@ -468,14 +463,11 @@ public interface IResend
     /// A Contact.
     /// </returns>
     /// <see href="https://resend.com/docs/api-reference/contacts/get-contact" />
-    Task<ResendResponse<Contact>> ContactRetrieveByEmailAsync( Guid audienceId, string email, CancellationToken cancellationToken = default );
+    Task<ResendResponse<Contact>> ContactRetrieveByEmailAsync( string email, CancellationToken cancellationToken = default );
 
     /// <summary>
     /// Update an existing contact.
     /// </summary>
-    /// <param name="audienceId">
-    /// Audience identifier.
-    /// </param>
     /// <param name="contactId">
     /// Contact identifier.
     /// </param>
@@ -489,14 +481,11 @@ public interface IResend
     /// Task.
     /// </returns>
     /// <see href="https://resend.com/docs/api-reference/contacts/update-contact" />
-    Task<ResendResponse> ContactUpdateAsync( Guid audienceId, Guid contactId, ContactData data, CancellationToken cancellationToken = default );
+    Task<ResendResponse> ContactUpdateAsync( Guid contactId, ContactData data, CancellationToken cancellationToken = default );
 
     /// <summary>
     /// Update an existing contact.
     /// </summary>
-    /// <param name="audienceId">
-    /// Audience identifier.
-    /// </param>
     /// <param name="email">
     /// Email.
     /// </param>
@@ -510,14 +499,11 @@ public interface IResend
     /// Task.
     /// </returns>
     /// <see href="https://resend.com/docs/api-reference/contacts/update-contact" />
-    Task<ResendResponse> ContactUpdateByEmailAsync( Guid audienceId, string email, ContactData data, CancellationToken cancellationToken = default );
+    Task<ResendResponse> ContactUpdateByEmailAsync( string email, ContactData data, CancellationToken cancellationToken = default );
 
     /// <summary>
     /// Remove a contact.
     /// </summary>
-    /// <param name="audienceId">
-    /// Audience identifier.
-    /// </param>
     /// <param name="contactId">
     /// Contact identifier.
     /// </param>
@@ -528,14 +514,11 @@ public interface IResend
     /// Task.
     /// </returns>
     /// <see href="https://resend.com/docs/api-reference/contacts/delete-contact" />
-    Task<ResendResponse> ContactDeleteAsync( Guid audienceId, Guid contactId, CancellationToken cancellationToken = default );
+    Task<ResendResponse> ContactDeleteAsync( Guid contactId, CancellationToken cancellationToken = default );
 
     /// <summary>
     /// Remove a contact by their email address.
     /// </summary>
-    /// <param name="audienceId">
-    /// Audience identifier.
-    /// </param>
     /// <param name="email">
     /// Email address of the contact.
     /// </param>
@@ -546,14 +529,11 @@ public interface IResend
     /// Task
     /// </returns>
     /// <see href="https://resend.com/docs/api-reference/contacts/delete-contact" />
-    Task<ResendResponse> ContactDeleteByEmailAsync( Guid audienceId, string email, CancellationToken cancellationToken = default );
+    Task<ResendResponse> ContactDeleteByEmailAsync( string email, CancellationToken cancellationToken = default );
 
     /// <summary>
-    /// List contacts from an audience.
+    /// List contacts.
     /// </summary>
-    /// <param name="audienceId">
-    /// Audience identifier.
-    /// </param>
     /// <param name="query">
     /// Paginated query.
     /// </param>
@@ -564,10 +544,10 @@ public interface IResend
     /// List of contacts.
     /// </returns>
     /// <see href="https://resend.com/docs/api-reference/contacts/list-contacts" />
-    Task<ResendResponse<PaginatedResult<Contact>>> ContactListAsync( Guid audienceId, PaginatedQuery? query = null, CancellationToken cancellationToken = default );
+    Task<ResendResponse<PaginatedResult<Contact>>> ContactListAsync( PaginatedQuery? query = null, CancellationToken cancellationToken = default );
 
     /// <summary>
-    /// Lists contact segments,.
+    /// Lists segments for a contact.
     /// </summary>
     /// <param name="contactId">Contact identifier.</param>
     /// <param name="query">Paginated query.</param>

--- a/src/Resend/ResendClient.Contacts.cs
+++ b/src/Resend/ResendClient.Contacts.cs
@@ -1,19 +1,18 @@
 ﻿using Microsoft.AspNetCore.WebUtilities;
 using Resend.Payloads;
 using System.Net.Http.Json;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Resend;
 
 public partial class ResendClient
 {
     /// <inheritdoc/>
-    public Task<ResendResponse<Guid>> ContactAddAsync( Guid audienceId, ContactData data, CancellationToken cancellationToken = default )
+    public Task<ResendResponse<Guid>> ContactAddAsync( ContactData data, CancellationToken cancellationToken = default )
     {
         if ( data.Email == null )
             throw new ArgumentException( "Email must be non-null when creating contact", nameof( data ) + ".Email" );
 
-        var path = $"/audiences/{audienceId}/contacts";
+        var path = $"/contacts";
         var req = new HttpRequestMessage( HttpMethod.Post, path );
         req.Content = JsonContent.Create( data );
 
@@ -22,9 +21,9 @@ public partial class ResendClient
 
 
     /// <inheritdoc/>
-    public Task<ResendResponse<Contact>> ContactRetrieveAsync( Guid audienceId, Guid contactId, CancellationToken cancellationToken = default )
+    public Task<ResendResponse<Contact>> ContactRetrieveAsync( Guid contactId, CancellationToken cancellationToken = default )
     {
-        var path = $"/audiences/{audienceId}/contacts/{contactId}";
+        var path = $"/contacts/{contactId}";
         var req = new HttpRequestMessage( HttpMethod.Get, path );
 
         return Execute<Contact, Contact>( req, ( x ) => x, cancellationToken );
@@ -32,9 +31,9 @@ public partial class ResendClient
 
 
     /// <inheritdoc/>
-    public Task<ResendResponse<Contact>> ContactRetrieveByEmailAsync( Guid audienceId, string email, CancellationToken cancellationToken = default )
+    public Task<ResendResponse<Contact>> ContactRetrieveByEmailAsync( string email, CancellationToken cancellationToken = default )
     {
-        var path = $"/audiences/{audienceId}/contacts/{email}";
+        var path = $"/contacts/{email}";
         var req = new HttpRequestMessage( HttpMethod.Get, path );
 
         return Execute<Contact, Contact>( req, ( x ) => x, cancellationToken );
@@ -42,9 +41,9 @@ public partial class ResendClient
 
 
     /// <inheritdoc/>
-    public Task<ResendResponse> ContactUpdateAsync( Guid audienceId, Guid contactId, ContactData data, CancellationToken cancellationToken = default )
+    public Task<ResendResponse> ContactUpdateAsync( Guid contactId, ContactData data, CancellationToken cancellationToken = default )
     {
-        var path = $"/audiences/{audienceId}/contacts/{contactId}";
+        var path = $"/contacts/{contactId}";
         var req = new HttpRequestMessage( HttpMethod.Patch, path );
         req.Content = JsonContent.Create( data );
 
@@ -53,9 +52,9 @@ public partial class ResendClient
 
 
     /// <inheritdoc/>
-    public Task<ResendResponse> ContactUpdateByEmailAsync( Guid audienceId, string email, ContactData data, CancellationToken cancellationToken = default )
+    public Task<ResendResponse> ContactUpdateByEmailAsync( string email, ContactData data, CancellationToken cancellationToken = default )
     {
-        var path = $"/audiences/{audienceId}/contacts/{email}";
+        var path = $"/contacts/{email}";
         var req = new HttpRequestMessage( HttpMethod.Patch, path );
         req.Content = JsonContent.Create( data );
 
@@ -64,9 +63,9 @@ public partial class ResendClient
 
 
     /// <inheritdoc/>
-    public Task<ResendResponse> ContactDeleteAsync( Guid audienceId, Guid contactId, CancellationToken cancellationToken = default )
+    public Task<ResendResponse> ContactDeleteAsync( Guid contactId, CancellationToken cancellationToken = default )
     {
-        var path = $"/audiences/{audienceId}/contacts/{contactId}";
+        var path = $"/contacts/{contactId}";
         var req = new HttpRequestMessage( HttpMethod.Delete, path );
 
         return Execute( req, cancellationToken );
@@ -74,9 +73,9 @@ public partial class ResendClient
 
 
     /// <inheritdoc/>
-    public Task<ResendResponse> ContactDeleteByEmailAsync( Guid audienceId, string email, CancellationToken cancellationToken = default )
+    public Task<ResendResponse> ContactDeleteByEmailAsync( string email, CancellationToken cancellationToken = default )
     {
-        var path = $"/audiences/{audienceId}/contacts/{email}";
+        var path = $"/contacts/{email}";
         var req = new HttpRequestMessage( HttpMethod.Delete, path );
 
         return Execute( req, cancellationToken );
@@ -84,9 +83,9 @@ public partial class ResendClient
 
 
     /// <inheritdoc/>
-    public Task<ResendResponse<PaginatedResult<Contact>>> ContactListAsync( Guid audienceId, PaginatedQuery? query = null, CancellationToken cancellationToken = default )
+    public Task<ResendResponse<PaginatedResult<Contact>>> ContactListAsync( PaginatedQuery? query = null, CancellationToken cancellationToken = default )
     {
-        var baseUrl = $"/audiences/{audienceId}/contacts";
+        var baseUrl = $"/contacts";
         var url = baseUrl;
 
         if ( query != null )

--- a/src/Resend/ResendException.cs
+++ b/src/Resend/ResendException.cs
@@ -52,7 +52,10 @@ public class ResendException : ApplicationException
             return this.ErrorType switch
             {
                 ErrorType.MissingApiKey => true,
+                ErrorType.InvalidApiKey => true,
+                ErrorType.InvalidAccess => true,
 
+                ErrorType.MonthlyQuotaExceeded => true,
                 ErrorType.DailyQuotaExceeded => true,
                 ErrorType.RateLimitExceeded => true,
                 ErrorType.HttpSendFailed => true,

--- a/src/Resend/ResendException.cs
+++ b/src/Resend/ResendException.cs
@@ -51,10 +51,6 @@ public class ResendException : ApplicationException
         {
             return this.ErrorType switch
             {
-                ErrorType.MissingApiKey => true,
-                ErrorType.InvalidApiKey => true,
-                ErrorType.InvalidAccess => true,
-
                 ErrorType.MonthlyQuotaExceeded => true,
                 ErrorType.DailyQuotaExceeded => true,
                 ErrorType.RateLimitExceeded => true,

--- a/tests/Resend.Tests/ResendClientTests.cs
+++ b/tests/Resend.Tests/ResendClientTests.cs
@@ -226,47 +226,6 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
 
     /// <summary/>
     [Fact]
-    public async Task AudienceCreate()
-    {
-        var resp = await _resend.AudienceAddAsync( "audience-test" );
-
-        Assert.NotNull( resp );
-        Assert.NotEqual( Guid.Empty, resp.Content );
-    }
-
-
-    /// <summary/>
-    [Fact]
-    public async Task AudienceRetrieve()
-    {
-        var resp = await _resend.AudienceRetrieveAsync( Guid.NewGuid() );
-
-        Assert.NotNull( resp );
-    }
-
-
-    /// <summary/>
-    [Fact]
-    public async Task AudienceList()
-    {
-        var resp = await _resend.AudienceListAsync();
-
-        Assert.NotNull( resp );
-    }
-
-
-    /// <summary/>
-    [Fact]
-    public async Task AudienceDelete()
-    {
-        var resp = await _resend.AudienceDeleteAsync( Guid.NewGuid() );
-
-        Assert.NotNull( resp );
-    }
-
-
-    /// <summary/>
-    [Fact]
     public async Task ContactCreate()
     {
         var req = new ContactData()
@@ -277,7 +236,7 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
             IsUnsubscribed = true,
         };
 
-        var resp = await _resend.ContactAddAsync( Guid.NewGuid(), req );
+        var resp = await _resend.ContactAddAsync( req );
 
         Assert.NotNull( resp );
         Assert.NotEqual( Guid.Empty, resp.Content );
@@ -288,7 +247,7 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
     [Fact]
     public async Task ContactRetrieve()
     {
-        var resp = await _resend.ContactRetrieveAsync( Guid.NewGuid(), Guid.NewGuid() );
+        var resp = await _resend.ContactRetrieveAsync( Guid.NewGuid() );
 
         Assert.NotNull( resp );
     }
@@ -298,7 +257,7 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
     [Fact]
     public async Task ContactRetrieveByEmail()
     {
-        var resp = await _resend.ContactRetrieveByEmailAsync( Guid.NewGuid(), "test@email.com" );
+        var resp = await _resend.ContactRetrieveByEmailAsync( "test@email.com" );
 
         Assert.NotNull( resp );
     }
@@ -316,7 +275,7 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
             IsUnsubscribed = true,
         };
 
-        var resp = await _resend.ContactUpdateAsync( Guid.NewGuid(), Guid.NewGuid(), req );
+        var resp = await _resend.ContactUpdateAsync( Guid.NewGuid(), req );
 
         Assert.NotNull( resp );
     }
@@ -333,7 +292,7 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
             IsUnsubscribed = true,
         };
 
-        var resp = await _resend.ContactUpdateByEmailAsync( Guid.NewGuid(), "test@email.com", req );
+        var resp = await _resend.ContactUpdateByEmailAsync( "test@email.com", req );
 
         Assert.NotNull( resp );
     }
@@ -343,7 +302,7 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
     [Fact]
     public async Task ContactList()
     {
-        var resp = await _resend.ContactListAsync( Guid.NewGuid() );
+        var resp = await _resend.ContactListAsync();
 
         Assert.NotNull( resp );
     }
@@ -353,7 +312,7 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
     [Fact]
     public async Task ContactDelete()
     {
-        var resp = await _resend.ContactDeleteAsync( Guid.NewGuid(), Guid.NewGuid() );
+        var resp = await _resend.ContactDeleteAsync( Guid.NewGuid() );
 
         Assert.NotNull( resp );
     }
@@ -363,7 +322,7 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
     [Fact]
     public async Task ContactDeleteByEmail()
     {
-        var resp = await _resend.ContactDeleteByEmailAsync( Guid.NewGuid(), "test@email.com" );
+        var resp = await _resend.ContactDeleteByEmailAsync( "test@email.com" );
 
         Assert.NotNull( resp );
     }

--- a/tests/Resend.Tests/ResendClientTests.cs
+++ b/tests/Resend.Tests/ResendClientTests.cs
@@ -334,7 +334,7 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
     {
         var req = new BroadcastData()
         {
-            AudienceId = Guid.NewGuid(),
+            SegmentId = Guid.NewGuid(),
             DisplayName = "Display Name",
             Subject = "Unit testing",
             From = "from@example.com",

--- a/tools/Resend.ApiServer/Controllers/BroadcastController.cs
+++ b/tools/Resend.ApiServer/Controllers/BroadcastController.cs
@@ -42,7 +42,7 @@ public class BroadcastController : ControllerBase
         return new Broadcast()
         {
             Id = broadcastId,
-            AudienceId = Guid.NewGuid(),
+            SegmentId = Guid.NewGuid(),
             DisplayName = "Display Name",
             Status = BroadcastStatus.Draft,
             MomentCreated = DateTime.UtcNow,
@@ -102,7 +102,7 @@ public class BroadcastController : ControllerBase
         list.Add( new Broadcast()
         {
             Id = Guid.NewGuid(),
-            AudienceId = Guid.NewGuid(),
+            SegmentId = Guid.NewGuid(),
             DisplayName = "In draft",
             Status = BroadcastStatus.Draft,
             MomentCreated = DateTime.UtcNow,
@@ -111,7 +111,7 @@ public class BroadcastController : ControllerBase
         list.Add( new Broadcast()
         {
             Id = Guid.NewGuid(),
-            AudienceId = Guid.NewGuid(),
+            SegmentId = Guid.NewGuid(),
             DisplayName = "Scheduled",
             Status = BroadcastStatus.Draft,
             MomentCreated = DateTime.UtcNow,
@@ -121,7 +121,7 @@ public class BroadcastController : ControllerBase
         list.Add( new Broadcast()
         {
             Id = Guid.NewGuid(),
-            AudienceId = Guid.NewGuid(),
+            SegmentId = Guid.NewGuid(),
             DisplayName = "Sent",
             Status = BroadcastStatus.Sent,
             MomentCreated = DateTime.UtcNow.AddDays( -10 ),

--- a/tools/Resend.ApiServer/Controllers/ContactController.cs
+++ b/tools/Resend.ApiServer/Controllers/ContactController.cs
@@ -19,8 +19,8 @@ public class ContactController : ControllerBase
 
     /// <summary />
     [HttpPost]
-    [Route( "audiences/{audienceId}/contacts" )]
-    public ObjectId ContactAdd( [FromRoute] Guid audienceId, [FromBody] ContactData message )
+    [Route( "contacts" )]
+    public ObjectId ContactAdd( [FromBody] ContactData message )
     {
         _logger.LogDebug( "ContactAdd" );
 
@@ -34,8 +34,8 @@ public class ContactController : ControllerBase
 
     /// <summary />
     [HttpGet]
-    [Route( "audiences/{audienceId}/contacts/{contactId:guid}" )]
-    public Contact ContactRetrieve( [FromRoute] Guid audienceId, [FromRoute] Guid contactId )
+    [Route( "contacts/{contactId:guid}" )]
+    public Contact ContactRetrieve( [FromRoute] Guid contactId )
     {
         _logger.LogDebug( "ContactRetrieve" );
 
@@ -53,8 +53,8 @@ public class ContactController : ControllerBase
 
     /// <summary />
     [HttpGet]
-    [Route( "audiences/{audienceId}/contacts/{email}" )]
-    public Contact ContactRetrieveByEmail( [FromRoute] Guid audienceId, [FromRoute] string email )
+    [Route( "contacts/{email}" )]
+    public Contact ContactRetrieveByEmail( [FromRoute] string email )
     {
         _logger.LogDebug( "ContactRetrieve" );
 
@@ -72,8 +72,8 @@ public class ContactController : ControllerBase
 
     /// <summary />
     [HttpPatch]
-    [Route( "audiences/{audienceId}/contacts/{contactId:guid}" )]
-    public ObjectId ContactUpdate( [FromRoute] Guid audienceId, [FromRoute] Guid contactId, [FromBody] ContactData message )
+    [Route( "contacts/{contactId:guid}" )]
+    public ObjectId ContactUpdate( [FromRoute] Guid contactId, [FromBody] ContactData message )
     {
         _logger.LogDebug( "ContactUpdate" );
 
@@ -87,8 +87,8 @@ public class ContactController : ControllerBase
 
     /// <summary />
     [HttpPatch]
-    [Route( "audiences/{audienceId}/contacts/{email}" )]
-    public ObjectId ContactUpdateByEmail( [FromRoute] Guid audienceId, [FromRoute] string email, [FromBody] ContactData message )
+    [Route( "contacts/{email}" )]
+    public ObjectId ContactUpdateByEmail( [FromRoute] string email, [FromBody] ContactData message )
     {
         _logger.LogDebug( "ContactUpdate" );
 
@@ -102,8 +102,8 @@ public class ContactController : ControllerBase
 
     /// <summary />
     [HttpDelete]
-    [Route( "audiences/{audienceId}/contacts/{contactId:guid}" )]
-    public ActionResult ContactDelete( [FromRoute] Guid audienceId, Guid contactId )
+    [Route( "contacts/{contactId:guid}" )]
+    public ActionResult ContactDelete( Guid contactId )
     {
         _logger.LogDebug( "ContactDelete" );
 
@@ -113,8 +113,8 @@ public class ContactController : ControllerBase
 
     /// <summary />
     [HttpDelete]
-    [Route( "audiences/{audienceId}/contacts/{email}" )]
-    public ActionResult ContactDeleteByEmail( [FromRoute] Guid audienceId, string email )
+    [Route( "contacts/{email}" )]
+    public ActionResult ContactDeleteByEmail( string email )
     {
         _logger.LogDebug( "ContactDeleteByEmail" );
 
@@ -124,8 +124,8 @@ public class ContactController : ControllerBase
 
     /// <summary />
     [HttpGet]
-    [Route( "audiences/{audienceId}/contacts" )]
-    public PaginatedResult<Contact> ContactList( [FromRoute] Guid audienceId )
+    [Route( "contacts" )]
+    public PaginatedResult<Contact> ContactList()
     {
         _logger.LogDebug( "ContactList" );
 

--- a/tools/Resend.Cli/Broadcast/BroadcastListCommand.cs
+++ b/tools/Resend.Cli/Broadcast/BroadcastListCommand.cs
@@ -41,8 +41,8 @@ public class BroadcastListCommand
         }
         else
         {
-            var res2 = await _resend.AudienceListAsync();
-            var audiences = res2.Content;
+            var res2 = await _resend.SegmentListAsync();
+            var segments = res2.Content.Data;
 
 
             var table = new Table();
@@ -57,11 +57,11 @@ public class BroadcastListCommand
 
             foreach ( var c in contacts )
             {
-                var aud = audiences.SingleOrDefault( x => x.Id == c.AudienceId );
+                var seg = segments.SingleOrDefault( x => x.Id == c.SegmentId );
 
                 table.AddRow(
                    new Markup( c.Id.ToString() ),
-                   new Markup( aud?.Name ?? c.AudienceId.ToString() ),
+                   new Markup( seg?.Name ?? c.SegmentId.ToString() ),
                    new Markup( c.DisplayName ?? "" ),
                    new Markup( c.Status.ToString() ),
                    new Markup( c.MomentCreated.ToShortDateString() ),

--- a/tools/Resend.Cli/Contact/ContactAddCommand.cs
+++ b/tools/Resend.Cli/Contact/ContactAddCommand.cs
@@ -11,14 +11,9 @@ public class ContactAddCommand
 
 
     /// <summary />
-    [Argument( 0, Description = "Audience identifier" )]
+    [Argument( 0, Description = "Email" )]
     [Required]
-    public Guid? AudienceId { get; set; }
-
-    /// <summary />
-    [Option( "-e|--email", CommandOptionType.SingleValue, Description = "Email" )]
-    [Required]
-    public string Email { get; set; } = default!;
+    public string? Email { get; set; }
 
     /// <summary />
     [Option( "-f|--first", CommandOptionType.SingleValue, Description = "First name" )]
@@ -45,13 +40,13 @@ public class ContactAddCommand
     {
         var data = new ContactData()
         {
-            Email = this.Email,
+            Email = this.Email!,
             FirstName = this.FirstName,
             LastName = this.LastName,
             IsUnsubscribed = this.IsUnsubscribed,
         };
 
-        var res = await _resend.ContactAddAsync( this.AudienceId!.Value, data );
+        var res = await _resend.ContactAddAsync( data );
         var id = res.Content;
 
 

--- a/tools/Resend.Cli/Contact/ContactDeleteCommand.cs
+++ b/tools/Resend.Cli/Contact/ContactDeleteCommand.cs
@@ -11,12 +11,7 @@ public class ContactDeleteCommand
 
 
     /// <summary />
-    [Argument( 0, Description = "Audience identifier" )]
-    [Required]
-    public Guid? AudienceId { get; set; }
-
-    /// <summary />
-    [Argument( 1, Description = "Contact identifier" )]
+    [Argument( 0, Description = "Contact identifier" )]
     [Required]
     public Guid? ContactId { get; set; }
 
@@ -31,7 +26,7 @@ public class ContactDeleteCommand
     /// <summary />
     public async Task<int> OnExecuteAsync()
     {
-        await _resend.ContactDeleteAsync( this.AudienceId!.Value, this.ContactId!.Value );
+        await _resend.ContactDeleteAsync( this.ContactId!.Value );
 
         return 0;
     }

--- a/tools/Resend.Cli/Contact/ContactListCommand.cs
+++ b/tools/Resend.Cli/Contact/ContactListCommand.cs
@@ -12,11 +12,6 @@ public class ContactListCommand
     private readonly IResend _resend;
 
     /// <summary />
-    [Argument( 0, Description = "Audience identifier" )]
-    [Required]
-    public Guid? AudienceId { get; set; }
-
-    /// <summary />
     [Option( "-j|--json", CommandOptionType.NoValue, Description = "Emit output as JSON array" )]
     public bool InJson { get; set; }
 
@@ -31,7 +26,7 @@ public class ContactListCommand
     /// <summary />
     public async Task<int> OnExecuteAsync()
     {
-        var res = await _resend.ContactListAsync( this.AudienceId!.Value );
+        var res = await _resend.ContactListAsync();
         var rows = res.Content.Data;
 
         if ( this.InJson == true )

--- a/tools/Resend.Cli/Contact/ContactRetrieveCommand.cs
+++ b/tools/Resend.Cli/Contact/ContactRetrieveCommand.cs
@@ -13,12 +13,7 @@ public class ContactRetrieveCommand
 
 
     /// <summary />
-    [Argument( 0, Description = "Audience identifier" )]
-    [Required]
-    public Guid? AudienceId { get; set; }
-
-    /// <summary />
-    [Argument( 1, Description = "Contact identifier or email" )]
+    [Argument( 0, Description = "Contact identifier or email" )]
     [Required]
     public string? Contact { get; set; }
 
@@ -44,7 +39,7 @@ public class ContactRetrieveCommand
 
         if ( this.Contact!.Contains( "@" ) == true )
         {
-            var res = await _resend.ContactRetrieveByEmailAsync( this.AudienceId!.Value, this.Contact! );
+            var res = await _resend.ContactRetrieveByEmailAsync( this.Contact! );
             contact = res.Content;
         }
         else
@@ -55,7 +50,7 @@ public class ContactRetrieveCommand
                 return 1;
             }
 
-            var res = await _resend.ContactRetrieveAsync( this.AudienceId!.Value, contactId );
+            var res = await _resend.ContactRetrieveAsync( contactId );
             contact = res.Content;
         }
 

--- a/tools/Resend.Cli/Contact/ContactUpdateCommand.cs
+++ b/tools/Resend.Cli/Contact/ContactUpdateCommand.cs
@@ -10,12 +10,7 @@ public class ContactUpdateCommand
     private readonly IResend _resend;
 
     /// <summary />
-    [Argument( 0, Description = "Audience identifier" )]
-    [Required]
-    public Guid? AudienceId { get; set; }
-
-    /// <summary />
-    [Argument( 1, Description = "Contact identifier" )]
+    [Argument( 0, Description = "Contact identifier" )]
     [Required]
     public Guid? ContactId { get; set; }
 
@@ -54,7 +49,7 @@ public class ContactUpdateCommand
             IsUnsubscribed = this.IsUnsubscribed,
         };
 
-        await _resend.ContactUpdateAsync( this.AudienceId!.Value, this.ContactId!.Value, data );
+        await _resend.ContactUpdateAsync( this.ContactId!.Value, data );
 
         return 0;
     }

--- a/tools/Resend.Cli/SegmentCommand.cs
+++ b/tools/Resend.Cli/SegmentCommand.cs
@@ -3,7 +3,7 @@
 namespace Resend.Cli;
 
 /// <summary />
-[Command( "segment", Description = "Segments management" )]
+[Command( "segment", Description = "Segments management (Deprecated)" )]
 [Subcommand( typeof( Segment.SegmentAddCommand ) )]
 [Subcommand( typeof( Segment.SegmentDeleteCommand ) )]
 [Subcommand( typeof( Segment.SegmentListCommand ) )]

--- a/tools/Resend.DocsCheck/Result.cs
+++ b/tools/Resend.DocsCheck/Result.cs
@@ -1,0 +1,22 @@
+﻿namespace Resend.DocsCheck;
+
+/// <summary>
+/// Code compilation result.
+/// </summary>
+public enum Result
+{
+    /// <summary>
+    /// Code sample compiles successfully.
+    /// </summary>
+    Ok,
+
+    /// <summary>
+    /// Code sample not written.
+    /// </summary>
+    Warn,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    Fail,
+}


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved Contacts to top-level endpoints and deprecated Audiences to align with the latest API, simplifying client calls and CLI usage. Also switched Broadcasts and contact webhooks to segments, added contact custom properties, and improved docs checking and transient error handling.

- **Refactors**
  - Contacts are no longer scoped to audiences; removed audienceId from all contact methods and switched paths to /contacts.
  - Marked Audience* methods as obsolete with guidance to use segments.
  - Updated API server routes from /audiences/{id}/contacts to /contacts.
  - Simplified CLI commands: contact operations no longer require an audienceId; first arg is now email or contactId as appropriate.
  - Broadcasts use segment_id; contact webhook payload now exposes segment_ids.
  - Updated transient errors: added MonthlyQuotaExceeded and removed API key-related errors.
  - Labeled the Segment CLI as “(Deprecated)”.
  - Contacts now support custom Properties key/value.

- **Migration**
  - Replace ContactAddAsync(Guid audienceId, ContactData) with ContactAddAsync(ContactData).
  - Replace ContactRetrieveAsync(Guid audienceId, Guid contactId) with ContactRetrieveAsync(Guid contactId).
  - Replace ContactRetrieveByEmailAsync(Guid audienceId, string email) with ContactRetrieveByEmailAsync(string email).
  - Replace ContactUpdateAsync(Guid audienceId, Guid contactId, ContactData) with ContactUpdateAsync(Guid contactId, ContactData).
  - Replace ContactUpdateByEmailAsync(Guid audienceId, string email, ContactData) with ContactUpdateByEmailAsync(string email, ContactData).
  - Replace ContactDeleteAsync(Guid audienceId, Guid contactId) with ContactDeleteAsync(Guid contactId).
  - Replace ContactDeleteByEmailAsync(Guid audienceId, string email) with ContactDeleteByEmailAsync(string email).
  - Replace ContactListAsync(Guid audienceId, PaginatedQuery?) with ContactListAsync(PaginatedQuery?).
  - Stop using Audience* methods; they’re obsolete and will be removed.

<sup>Written for commit 66e556b0140157a531b9c27f09ee6bea22adf802. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





