### PR TITLE
Fix FluentEmail display name being silently dropped

### DIFF
--- a/src/Resend.FluentEmail/ResendSender.cs
+++ b/src/Resend.FluentEmail/ResendSender.cs
@@ -233,7 +233,7 @@ public class ResendSender : ISender
         EmailAddress addr = new EmailAddress();
         addr.Email = fluentAddress.EmailAddress;
 
-        if ( string.IsNullOrEmpty( fluentAddress.Name ) == true )
+        if ( string.IsNullOrEmpty( fluentAddress.Name ) == false )
             addr.DisplayName = fluentAddress.Name;
 
         return addr;

--- a/tests/Resend.FluentEmail.Tests/DisplayNameBugTests.cs
+++ b/tests/Resend.FluentEmail.Tests/DisplayNameBugTests.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+using FluentEmail.Core.Models;
+
+namespace Resend.FluentEmail.Tests;
+
+/// <summary>
+/// Tests for display name handling in FluentEmail to Resend conversion.
+/// </summary>
+public class DisplayNameBugTests
+{
+    /// <summary />
+    private static EmailAddress InvokeToEmailAddress( Address fluentAddress )
+    {
+        var method = typeof( ResendSender ).GetMethod(
+            "ToEmailAddress",
+            BindingFlags.NonPublic | BindingFlags.Static );
+
+        return (EmailAddress) method!.Invoke( null, new object[] { fluentAddress } )!;
+    }
+
+
+    /// <summary />
+    [Fact]
+    public void WithDisplayName_ShouldPreserveIt()
+    {
+        var fluent = new Address( "john@example.com", "John Doe" );
+
+        var result = InvokeToEmailAddress( fluent );
+
+        Assert.Equal( "john@example.com", result.Email );
+        Assert.Equal( "John Doe", result.DisplayName );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public void WithDisplayName_ShouldSerializeCorrectly()
+    {
+        var fluent = new Address( "john@example.com", "John Doe" );
+
+        var result = InvokeToEmailAddress( fluent );
+
+        Assert.Equal( "John Doe <john@example.com>", result.ToString() );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public void WithoutDisplayName_ShouldNotSetDisplayName()
+    {
+        var fluent = new Address( "john@example.com" );
+
+        var result = InvokeToEmailAddress( fluent );
+
+        Assert.Equal( "john@example.com", result.Email );
+        Assert.Null( result.DisplayName );
+        Assert.Equal( "john@example.com", result.ToString() );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes inverted condition in `ResendSender.ToEmailAddress()` that caused display
names to be silently dropped when converting FluentEmail addresses to Resend
email addresses.


## Problem

The condition `string.IsNullOrEmpty( fluentAddress.Name ) == true` on line 236
only enters the assignment block when the name is null or empty, which means
display names with actual content (e.g., "John Doe") are always discarded.

This affects all FluentEmail users who pass display names via `.From()`, `.To()`,
`.CC()`, `.BCC()`, or `.ReplyTo()`. Emails still send successfully, so the data
loss is silent.


## Fix

Changed `== true` to `== false` so that `DisplayName` is set when a name is
actually present.


## Tests

Added `DisplayNameBugTests` with three test cases:
- Display name is preserved in the `EmailAddress` object
- Display name serializes correctly as `"Name <email>"` for the API
- No display name continues to work as before

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an inverted condition in ResendSender.ToEmailAddress that caused FluentEmail display names to be silently dropped. Display names from From/To/CC/BCC/ReplyTo are now preserved and serialize as "Name <email>" when present.

<sup>Written for commit 3fe56f926fd41b16ae4fa211602dab08e740b08c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

