### PR TITLE
feat: add support for Logs API

### DIFF
--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -1,4 +1,4 @@
-﻿namespace Resend;
+namespace Resend;
 
 /// <summary>
 /// Resend client.
@@ -962,6 +962,28 @@ public interface IResend
     /// <param name="cancellationToken">Cancelation token.</param>
     /// <returns>Response.</returns>
     Task<ResendResponse> WebhookDeleteAsync( Guid webhookId, CancellationToken cancellationToken = default );
+
+    #endregion
+
+    #region Logs
+
+    /// <summary>
+    /// Lists API request logs.
+    /// </summary>
+    /// <param name="query">Pagination query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Page of logs.</returns>
+    /// <see href="https://resend.com/docs/api-reference/logs/list-logs"/>
+    Task<ResendResponse<PaginatedResult<Log>>> LogListAsync( PaginatedQuery? query = null, CancellationToken cancellationToken = default );
+
+    /// <summary>
+    /// Retrieves a single API request log, including request and response bodies when available.
+    /// </summary>
+    /// <param name="logId">Log identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Log entry.</returns>
+    /// <see href="https://resend.com/docs/api-reference/logs/retrieve-log"/>
+    Task<ResendResponse<Log>> LogRetrieveAsync( Guid logId, CancellationToken cancellationToken = default );
 
     #endregion
 }

--- a/src/Resend/Log.cs
+++ b/src/Resend/Log.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// An entry from the API request logs.
+/// </summary>
+public class Log
+{
+    /// <summary>
+    /// Log identifier.
+    /// </summary>
+    [JsonPropertyName( "id" )]
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// When the request was logged.
+    /// </summary>
+    [JsonPropertyName( "created_at" )]
+    [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
+    public DateTime MomentCreated { get; set; }
+
+    /// <summary>
+    /// API path that was invoked (for example <c>/emails</c>).
+    /// </summary>
+    [JsonPropertyName( "endpoint" )]
+    public string Endpoint { get; set; } = default!;
+
+    /// <summary>
+    /// HTTP method (for example GET or POST).
+    /// </summary>
+    [JsonPropertyName( "method" )]
+    public string HttpMethod { get; set; } = default!;
+
+    /// <summary>
+    /// HTTP status code returned for the request.
+    /// </summary>
+    [JsonPropertyName( "response_status" )]
+    public int ResponseStatus { get; set; }
+
+    /// <summary>
+    /// User-Agent header sent with the request.
+    /// </summary>
+    [JsonPropertyName( "user_agent" )]
+    public string UserAgent { get; set; } = default!;
+
+    /// <summary>
+    /// Request body as logged. Shape depends on the API operation. Only present when retrieving a single log.
+    /// </summary>
+    [JsonPropertyName( "request_body" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public JsonElement? RequestBody { get; set; }
+
+    /// <summary>
+    /// Response body as logged. Shape depends on the API operation. Only present when retrieving a single log.
+    /// </summary>
+    [JsonPropertyName( "response_body" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public JsonElement? ResponseBody { get; set; }
+}

--- a/src/Resend/ResendClient.Logs.cs
+++ b/src/Resend/ResendClient.Logs.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace Resend;
+
+public partial class ResendClient
+{
+    /// <inheritdoc />
+    public Task<ResendResponse<PaginatedResult<Log>>> LogListAsync( PaginatedQuery? query = null, CancellationToken cancellationToken = default )
+    {
+        var baseUrl = "/logs";
+        var url = baseUrl;
+
+        if ( query != null )
+        {
+            var qs = new Dictionary<string, string?>();
+
+            if ( query.Limit.HasValue == true )
+                qs.Add( "limit", query.Limit.Value.ToString() );
+
+            if ( query.Before != null )
+                qs.Add( "before", query.Before );
+
+            if ( query.After != null )
+                qs.Add( "after", query.After );
+
+            url = QueryHelpers.AddQueryString( baseUrl, qs );
+        }
+
+        var req = new HttpRequestMessage( HttpMethod.Get, url );
+
+        return Execute<PaginatedResult<Log>, PaginatedResult<Log>>( req, ( x ) => x, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
+    public Task<ResendResponse<Log>> LogRetrieveAsync( Guid logId, CancellationToken cancellationToken = default )
+    {
+        var path = $"/logs/{logId}";
+        var req = new HttpRequestMessage( HttpMethod.Get, path );
+
+        return Execute<Log, Log>( req, ( x ) => x, cancellationToken );
+    }
+}

--- a/tests/Resend.Tests/ResendClientTests.Logs.cs
+++ b/tests/Resend.Tests/ResendClientTests.Logs.cs
@@ -1,0 +1,35 @@
+namespace Resend.Tests;
+
+/// <summary />
+public partial class ResendClientTests
+{
+    /// <summary/>
+    [Fact]
+    public async Task LogList()
+    {
+        var resp = await _resend.LogListAsync();
+
+        Assert.NotNull( resp );
+        Assert.NotNull( resp.Content );
+        Assert.False( resp.Content.HasMore );
+        Assert.Equal( 2, resp.Content.Data.Count );
+        Assert.Equal( "/emails", resp.Content.Data[ 0 ].Endpoint );
+        Assert.Equal( "POST", resp.Content.Data[ 0 ].HttpMethod );
+        Assert.Equal( 200, resp.Content.Data[ 0 ].ResponseStatus );
+    }
+
+
+    /// <summary/>
+    [Fact]
+    public async Task LogList_WithPaginationQuery()
+    {
+        var resp = await _resend.LogListAsync( new PaginatedQuery()
+        {
+            Limit = 20,
+            After = Guid.NewGuid().ToString(),
+        } );
+
+        Assert.NotNull( resp );
+        Assert.NotNull( resp.Content );
+    }
+}

--- a/tools/Resend.ApiServer/Controllers/LogController.cs
+++ b/tools/Resend.ApiServer/Controllers/LogController.cs
@@ -1,0 +1,83 @@
+using Microsoft.AspNetCore.Mvc;
+using System.Text.Json;
+
+namespace Resend.ApiServer.Controllers;
+
+/// <summary />
+[ApiController]
+public class LogController : ControllerBase
+{
+    private readonly ILogger<LogController> _logger;
+
+
+    /// <summary />
+    public LogController( ILogger<LogController> logger )
+    {
+        _logger = logger;
+    }
+
+
+    /// <summary />
+    [HttpGet]
+    [Route( "logs" )]
+    public PaginatedResult<Log> LogList(
+        [FromQuery] string? limit = null,
+        [FromQuery] string? before = null,
+        [FromQuery] string? after = null
+    )
+    {
+        _logger.LogDebug( "LogList" );
+
+        var id1 = Guid.Parse( "37e4414c-5e25-4dbc-a071-43552a4bd53b" );
+        var id2 = Guid.Parse( "a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d" );
+
+        return new PaginatedResult<Log>()
+        {
+            HasMore = false,
+            Data =
+            [
+                new Log()
+                {
+                    Id = id1,
+                    MomentCreated = DateTime.Parse( "2026-03-30 13:43:54.622865+00", null, System.Globalization.DateTimeStyles.RoundtripKind ),
+                    Endpoint = "/emails",
+                    HttpMethod = "POST",
+                    ResponseStatus = 200,
+                    UserAgent = "resend-node:6.0.3",
+                },
+                new Log()
+                {
+                    Id = id2,
+                    MomentCreated = DateTime.Parse( "2026-03-30 12:15:00.123456+00", null, System.Globalization.DateTimeStyles.RoundtripKind ),
+                    Endpoint = "/emails/4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
+                    HttpMethod = "GET",
+                    ResponseStatus = 200,
+                    UserAgent = "curl/8.7.1",
+                },
+            ],
+        };
+    }
+
+
+    /// <summary />
+    [HttpGet]
+    [Route( "logs/{id}" )]
+    public Log LogRetrieve( [FromRoute] Guid id )
+    {
+        _logger.LogDebug( "LogRetrieve" );
+
+        var responseBodyJson = $"{{\"id\":\"{id}\"}}";
+
+        return new Log()
+        {
+            Id = id,
+            MomentCreated = DateTime.UtcNow,
+            Endpoint = "/emails",
+            HttpMethod = "POST",
+            ResponseStatus = 200,
+            UserAgent = "resend-node:6.0.3",
+            RequestBody = JsonDocument.Parse( "{\"from\":\"sender@example.com\",\"to\":[\"recipient@example.com\"],\"subject\":\"Test subject\"}" ).RootElement,
+            ResponseBody = JsonDocument.Parse( responseBodyJson ).RootElement,
+        };
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for the Logs API to list and retrieve API request logs with pagination. Single-log retrieval includes request and response bodies; tests and local endpoints are included.

- **New Features**
  - Added `Log` model with metadata plus optional `request_body` and `response_body`.
  - Added `IResend` methods: `LogListAsync(PaginatedQuery?)` and `LogRetrieveAsync(Guid)`.
  - Implemented client calls for `GET /logs` (supports `limit`, `before`, `after`) and `GET /logs/{id}`.
  - Added tests for listing and pagination behavior.
  - Added local dev endpoints in `tools/Resend.ApiServer` to simulate the Logs API.

<sup>Written for commit e4db93976b8ac7a517b3f59c79d70518db07264e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

