### PR TITLE
feat: add support for custom tracking domains

### DIFF
--- a/src/Resend.Webhooks/DomainEventData.cs
+++ b/src/Resend.Webhooks/DomainEventData.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Resend.Webhooks;
 
@@ -33,6 +33,26 @@ public class DomainEventData : IWebhookData
     /// </summary>
     [JsonPropertyName( "region" )]
     public DeliveryRegion Region { get; set; }
+
+    /// <summary />
+    [JsonPropertyName( "open_tracking" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public bool? OpenTracking { get; set; }
+
+    /// <summary />
+    [JsonPropertyName( "click_tracking" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public bool? ClickTracking { get; set; }
+
+    /// <summary />
+    [JsonPropertyName( "tracking_subdomain" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? TrackingSubdomain { get; set; }
+
+    /// <summary />
+    [JsonPropertyName( "capabilities" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public DomainCapabilities? Capabilities { get; set; }
 
     /// <summary>
     /// DNS records used for domain validation.

--- a/src/Resend/Domain.cs
+++ b/src/Resend/Domain.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Resend;
 
@@ -35,6 +35,34 @@ public class Domain
     /// </summary>
     [JsonPropertyName( "region" )]
     public DeliveryRegion Region { get; set; }
+
+    /// <summary>
+    /// Whether open tracking is enabled for this domain.
+    /// </summary>
+    [JsonPropertyName( "open_tracking" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public bool? OpenTracking { get; set; }
+
+    /// <summary>
+    /// Whether click tracking is enabled for this domain.
+    /// </summary>
+    [JsonPropertyName( "click_tracking" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public bool? ClickTracking { get; set; }
+
+    /// <summary>
+    /// Subdomain used for click and open tracking URLs (for example, <c>links</c> for <c>links.example.com</c>).
+    /// </summary>
+    [JsonPropertyName( "tracking_subdomain" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? TrackingSubdomain { get; set; }
+
+    /// <summary>
+    /// Whether this domain can send and receive email.
+    /// </summary>
+    [JsonPropertyName( "capabilities" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public DomainCapabilities? Capabilities { get; set; }
 
     /// <summary>
     /// DNS records used for domain validation.

--- a/src/Resend/DomainAddData.cs
+++ b/src/Resend/DomainAddData.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Resend;
 
@@ -29,4 +29,39 @@ public class DomainAddData
     [JsonPropertyName( "custom_return_path" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
     public string? CustomReturnPath { get; set; }
+
+    /// <summary>
+    /// TLS mode for outbound mail from this domain.
+    /// </summary>
+    [JsonPropertyName( "tls" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public TlsMode? TlsMode { get; set; }
+
+    /// <summary>
+    /// Configure sending and receiving for this domain. At least one capability must remain enabled.
+    /// </summary>
+    [JsonPropertyName( "capabilities" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public DomainCapabilities? Capabilities { get; set; }
+
+    /// <summary>
+    /// Track the open rate of each email.
+    /// </summary>
+    [JsonPropertyName( "open_tracking" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public bool? OpenTracking { get; set; }
+
+    /// <summary>
+    /// Track clicks within the body of each HTML email.
+    /// </summary>
+    [JsonPropertyName( "click_tracking" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public bool? ClickTracking { get; set; }
+
+    /// <summary>
+    /// Subdomain for click and open tracking (for example, <c>links</c> for <c>links.example.com</c>).
+    /// </summary>
+    [JsonPropertyName( "tracking_subdomain" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? TrackingSubdomain { get; set; }
 }

--- a/src/Resend/DomainCapabilities.cs
+++ b/src/Resend/DomainCapabilities.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// Sending and receiving capabilities for a domain.
+/// </summary>
+public class DomainCapabilities
+{
+    /// <summary>
+    /// Whether sending is enabled for this domain. Example values: <c>enabled</c>, <c>disabled</c>.
+    /// </summary>
+    [JsonPropertyName( "sending" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? Sending { get; set; }
+
+    /// <summary>
+    /// Whether receiving is enabled for this domain. Example values: <c>enabled</c>, <c>disabled</c>.
+    /// </summary>
+    [JsonPropertyName( "receiving" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? Receiving { get; set; }
+}

--- a/src/Resend/DomainRecord.cs
+++ b/src/Resend/DomainRecord.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Resend;
 
@@ -7,7 +7,7 @@ public class DomainRecord
 {
     /// <summary />
     /// <remarks>
-    /// Example values: SPF, DKIM.
+    /// Example values: SPF, DKIM, Receiving, Tracking.
     /// </remarks>
     [JsonPropertyName( "record" )]
     public string Record { get; set; } = default!;

--- a/src/Resend/DomainUpdateData.cs
+++ b/src/Resend/DomainUpdateData.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Resend;
 
@@ -23,6 +23,24 @@ public class DomainUpdateData
     [JsonPropertyName( "tls" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
     public TlsMode? TlsMode { get; set; }
+
+    /// <summary>
+    /// Configure sending and receiving for this domain. At least one capability must remain enabled.
+    /// </summary>
+    [JsonPropertyName( "capabilities" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public DomainCapabilities? Capabilities { get; set; }
+
+    /// <summary>
+    /// Subdomain for click and open tracking (for example, <c>links</c> for <c>links.example.com</c>).
+    /// </summary>
+    /// <remarks>
+    /// This value can only be set after it has been specified, never cleared. After changing the tracking
+    /// subdomain, verify DNS again; until then, the previous value may still be used for tracked links.
+    /// </remarks>
+    [JsonPropertyName( "tracking_subdomain" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? TrackingSubdomain { get; set; }
 }
 
 

--- a/tests/Resend.Tests/DomainTests.cs
+++ b/tests/Resend.Tests/DomainTests.cs
@@ -1,0 +1,113 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace Resend.Tests;
+
+/// <summary />
+public class DomainTests
+{
+    /// <summary />
+    [Fact]
+    public void DomainAddData_serializes_capabilities_and_tls()
+    {
+        var data = new DomainAddData()
+        {
+            DomainName = "example.com",
+            TlsMode = TlsMode.Enforced,
+            Capabilities = new DomainCapabilities()
+            {
+                Sending = "enabled",
+                Receiving = "disabled",
+            },
+        };
+
+        var json = JsonSerializer.Serialize( data );
+        Assert.Contains( "\"tls\":\"enforced\"", json );
+        Assert.Contains( "\"capabilities\"", json );
+        Assert.Contains( "\"sending\":\"enabled\"", json );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public void DomainAddData_serializes_tracking_fields()
+    {
+        var data = new DomainAddData()
+        {
+            DomainName = "example.com",
+            ClickTracking = true,
+            TrackingSubdomain = "links",
+        };
+
+        var json = JsonSerializer.Serialize( data );
+        Assert.Contains( "\"click_tracking\":true", json );
+        Assert.Contains( "\"tracking_subdomain\":\"links\"", json );
+        Assert.DoesNotContain( "open_tracking", json );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public void Domain_deserializes_tracking_and_capabilities()
+    {
+        const string json = """
+            {
+              "id": "d91cd9bd-1176-453e-8fc1-35364d380206",
+              "name": "example.com",
+              "status": "not_started",
+              "created_at": "2023-04-26T20:21:26.347412+00:00",
+              "region": "us-east-1",
+              "open_tracking": true,
+              "click_tracking": false,
+              "tracking_subdomain": "links",
+              "capabilities": {
+                "sending": "enabled",
+                "receiving": "disabled"
+              },
+              "records": []
+            }
+            """;
+
+        var domain = JsonSerializer.Deserialize<Domain>( json );
+        Assert.NotNull( domain );
+        Assert.Equal( "links", domain!.TrackingSubdomain );
+        Assert.True( domain.OpenTracking );
+        Assert.False( domain.ClickTracking );
+        Assert.NotNull( domain.Capabilities );
+        Assert.Equal( "enabled", domain.Capabilities!.Sending );
+        Assert.Equal( "disabled", domain.Capabilities.Receiving );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public void DomainUpdateData_serializes_tracking_subdomain()
+    {
+        var data = new DomainUpdateData()
+        {
+            TrackClicks = true,
+            TrackOpen = false,
+            TrackingSubdomain = "links",
+        };
+
+        var json = JsonSerializer.Serialize( data );
+        Assert.Contains( "\"tracking_subdomain\":\"links\"", json );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task JsonContent_Create_omits_null_tracking_subdomain_on_update()
+    {
+        var data = new DomainUpdateData()
+        {
+            TrackClicks = true,
+            TrackOpen = true,
+            TrackingSubdomain = null,
+        };
+
+        using var content = JsonContent.Create( data );
+        var json = await content.ReadAsStringAsync();
+        Assert.DoesNotContain( "tracking_subdomain", json );
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add custom tracking domains and tracking controls to domain APIs and webhooks. You can set a tracking subdomain and enable/disable click and open tracking, plus manage sending/receiving capabilities.

- **New Features**
  - Domain models (`Domain`, `DomainEventData`) now include `open_tracking`, `click_tracking`, `tracking_subdomain`, and `capabilities`.
  - `DomainAddData`: add `open_tracking`, `click_tracking`, `tracking_subdomain`, `tls`, and `capabilities`.
  - `DomainUpdateData`: add `capabilities` and `tracking_subdomain` (omitted when null).
  - New `DomainCapabilities` with `sending` and `receiving`.
  - `DomainRecord` examples now include Tracking.
  - Tests cover JSON (de)serialization for capabilities and tracking.

- **Migration**
  - Set DNS for the tracking subdomain (e.g., CNAME for `links.example.com`) and re-verify the domain after changes.
  - `tracking_subdomain` cannot be cleared once set; updates require DNS re-verification.

<sup>Written for commit 8f8ea060d967eddc478071e6eff082444c6c41e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

