### PR TITLE
chore: align Events and Automations APIs with latest OpenAPI spec

### DIFF
--- a/src/Resend/Automation.cs
+++ b/src/Resend/Automation.cs
@@ -52,8 +52,8 @@ public class Automation
     public List<AutomationStep> Steps { get; set; } = default!;
 
     /// <summary>
-    /// Edges connecting steps.
+    /// Connections between steps.
     /// </summary>
-    [JsonPropertyName( "edges" )]
-    public List<AutomationEdge> Edges { get; set; } = default!;
+    [JsonPropertyName( "connections" )]
+    public List<AutomationEdge> Connections { get; set; } = default!;
 }

--- a/src/Resend/AutomationCreateData.cs
+++ b/src/Resend/AutomationCreateData.cs
@@ -27,8 +27,8 @@ public class AutomationCreateData
     public List<AutomationStepData> Steps { get; set; } = default!;
 
     /// <summary>
-    /// Edges between steps (may be empty for single-step automations).
+    /// Connections between steps (may be empty for single-step automations).
     /// </summary>
-    [JsonPropertyName( "edges" )]
-    public List<AutomationEdge> Edges { get; set; } = default!;
+    [JsonPropertyName( "connections" )]
+    public List<AutomationEdge> Connections { get; set; } = default!;
 }

--- a/src/Resend/AutomationEdge.cs
+++ b/src/Resend/AutomationEdge.cs
@@ -24,9 +24,9 @@ public class AutomationEdge
     public string To { get; set; } = default!;
 
     /// <summary>
-    /// Edge kind: <c>default</c>, <c>condition_met</c>, <c>condition_not_met</c>, <c>timeout</c>, <c>event_received</c>.
+    /// Connection type: <c>default</c>, <c>condition_met</c>, <c>condition_not_met</c>, <c>timeout</c>, <c>event_received</c>.
     /// </summary>
-    [JsonPropertyName( "edge_type" )]
+    [JsonPropertyName( "type" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
     public string? EdgeType { get; set; }
 }

--- a/src/Resend/AutomationRun.cs
+++ b/src/Resend/AutomationRun.cs
@@ -30,7 +30,7 @@ public class AutomationRun
     /// </summary>
     [JsonPropertyName( "started_at" )]
     [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
-    public DateTime MomentStarted { get; set; }
+    public DateTime? MomentStarted { get; set; }
 
     /// <summary>
     /// When the run finished, if applicable.

--- a/src/Resend/AutomationRunStep.cs
+++ b/src/Resend/AutomationRunStep.cs
@@ -9,6 +9,12 @@ namespace Resend;
 public class AutomationRunStep
 {
     /// <summary>
+    /// Unique key identifying this step within the automation graph.
+    /// </summary>
+    [JsonPropertyName( "key" )]
+    public string? Key { get; set; }
+
+    /// <summary>
     /// Step type.
     /// </summary>
     [JsonPropertyName( "type" )]
@@ -25,7 +31,7 @@ public class AutomationRunStep
     /// </summary>
     [JsonPropertyName( "started_at" )]
     [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
-    public DateTime MomentStarted { get; set; }
+    public DateTime? MomentStarted { get; set; }
 
     /// <summary>
     /// When the step finished, if applicable.

--- a/src/Resend/AutomationRunSummary.cs
+++ b/src/Resend/AutomationRunSummary.cs
@@ -24,7 +24,7 @@ public class AutomationRunSummary
     /// </summary>
     [JsonPropertyName( "started_at" )]
     [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
-    public DateTime MomentStarted { get; set; }
+    public DateTime? MomentStarted { get; set; }
 
     /// <summary>
     /// When the run finished, if applicable.

--- a/src/Resend/AutomationStep.cs
+++ b/src/Resend/AutomationStep.cs
@@ -4,10 +4,16 @@ using System.Text.Json.Serialization;
 namespace Resend;
 
 /// <summary>
-/// A step returned when retrieving an automation (responses omit per-step <c>ref</c>).
+/// A step returned when retrieving an automation.
 /// </summary>
 public class AutomationStep
 {
+    /// <summary>
+    /// Unique key identifying this step within the automation graph.
+    /// </summary>
+    [JsonPropertyName( "key" )]
+    public string? Key { get; set; }
+
     /// <summary>
     /// Step type.
     /// </summary>

--- a/src/Resend/AutomationUpdateData.cs
+++ b/src/Resend/AutomationUpdateData.cs
@@ -30,9 +30,9 @@ public class AutomationUpdateData
     public List<AutomationStepData>? Steps { get; set; }
 
     /// <summary>
-    /// Replacement edge list when updating the graph.
+    /// Replacement connection list when updating the graph.
     /// </summary>
-    [JsonPropertyName( "edges" )]
+    [JsonPropertyName( "connections" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-    public List<AutomationEdge>? Edges { get; set; }
+    public List<AutomationEdge>? Connections { get; set; }
 }

--- a/src/Resend/EventDeleteResult.cs
+++ b/src/Resend/EventDeleteResult.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// Response returned when deleting an event definition.
+/// </summary>
+public class EventDeleteResult
+{
+    /// <summary>
+    /// Object type discriminator.
+    /// </summary>
+    [JsonPropertyName( "object" )]
+    public string Object { get; set; } = default!;
+
+    /// <summary>
+    /// Event identifier.
+    /// </summary>
+    [JsonPropertyName( "id" )]
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Whether the event was deleted.
+    /// </summary>
+    [JsonPropertyName( "deleted" )]
+    public bool Deleted { get; set; }
+}

--- a/src/Resend/EventResource.cs
+++ b/src/Resend/EventResource.cs
@@ -45,5 +45,5 @@ public class EventResource
     /// </summary>
     [JsonPropertyName( "updated_at" )]
     [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
-    public DateTime MomentUpdated { get; set; }
+    public DateTime? MomentUpdated { get; set; }
 }

--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -1106,9 +1106,9 @@ public interface IResend
     /// <param name="eventId">Event identifier.</param>
     /// <param name="data">Fields to update.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Response.</returns>
+    /// <returns>ID of the updated event.</returns>
     /// <see href="https://resend.com/docs/api-reference/events/update-event"/>
-    Task<ResendResponse> EventUpdateAsync( Guid eventId, EventUpdateData data, CancellationToken cancellationToken = default );
+    Task<ResendResponse<Guid>> EventUpdateAsync( Guid eventId, EventUpdateData data, CancellationToken cancellationToken = default );
 
     /// <summary>
     /// Updates an event definition by identifier or name.
@@ -1116,27 +1116,27 @@ public interface IResend
     /// <param name="eventIdOrName">Event id (UUID) or name.</param>
     /// <param name="data">Fields to update.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Response.</returns>
+    /// <returns>ID of the updated event.</returns>
     /// <see href="https://resend.com/docs/api-reference/events/update-event"/>
-    Task<ResendResponse> EventUpdateAsync( string eventIdOrName, EventUpdateData data, CancellationToken cancellationToken = default );
+    Task<ResendResponse<Guid>> EventUpdateAsync( string eventIdOrName, EventUpdateData data, CancellationToken cancellationToken = default );
 
     /// <summary>
     /// Deletes an event definition.
     /// </summary>
     /// <param name="eventId">Event identifier.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Response.</returns>
+    /// <returns>Delete result including the event id and confirmation flag.</returns>
     /// <see href="https://resend.com/docs/api-reference/events/delete-event"/>
-    Task<ResendResponse> EventDeleteAsync( Guid eventId, CancellationToken cancellationToken = default );
+    Task<ResendResponse<EventDeleteResult>> EventDeleteAsync( Guid eventId, CancellationToken cancellationToken = default );
 
     /// <summary>
     /// Deletes an event definition by identifier or name.
     /// </summary>
     /// <param name="eventIdOrName">Event id (UUID) or name.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Response.</returns>
+    /// <returns>Delete result including the event id and confirmation flag.</returns>
     /// <see href="https://resend.com/docs/api-reference/events/delete-event"/>
-    Task<ResendResponse> EventDeleteAsync( string eventIdOrName, CancellationToken cancellationToken = default );
+    Task<ResendResponse<EventDeleteResult>> EventDeleteAsync( string eventIdOrName, CancellationToken cancellationToken = default );
 
     /// <summary>
     /// Sends a named event (for example to trigger automations).

--- a/src/Resend/ResendClient.Events.cs
+++ b/src/Resend/ResendClient.Events.cs
@@ -63,40 +63,40 @@ public partial class ResendClient
 
 
     /// <inheritdoc />
-    public Task<ResendResponse> EventUpdateAsync( Guid eventId, EventUpdateData data, CancellationToken cancellationToken = default )
+    public Task<ResendResponse<Guid>> EventUpdateAsync( Guid eventId, EventUpdateData data, CancellationToken cancellationToken = default )
     {
         var req = new HttpRequestMessage( HttpMethod.Patch, $"/events/{eventId}" );
         req.Content = JsonContent.Create( data );
 
-        return Execute( req, cancellationToken );
+        return Execute<ObjectId, Guid>( req, ( x ) => x.Id, cancellationToken );
     }
 
 
     /// <inheritdoc />
-    public Task<ResendResponse> EventUpdateAsync( string eventIdOrName, EventUpdateData data, CancellationToken cancellationToken = default )
+    public Task<ResendResponse<Guid>> EventUpdateAsync( string eventIdOrName, EventUpdateData data, CancellationToken cancellationToken = default )
     {
         var req = new HttpRequestMessage( HttpMethod.Patch, $"/events/{Uri.EscapeDataString( eventIdOrName )}" );
         req.Content = JsonContent.Create( data );
 
-        return Execute( req, cancellationToken );
+        return Execute<ObjectId, Guid>( req, ( x ) => x.Id, cancellationToken );
     }
 
 
     /// <inheritdoc />
-    public Task<ResendResponse> EventDeleteAsync( Guid eventId, CancellationToken cancellationToken = default )
+    public Task<ResendResponse<EventDeleteResult>> EventDeleteAsync( Guid eventId, CancellationToken cancellationToken = default )
     {
         var req = new HttpRequestMessage( HttpMethod.Delete, $"/events/{eventId}" );
 
-        return Execute( req, cancellationToken );
+        return Execute<EventDeleteResult, EventDeleteResult>( req, ( x ) => x, cancellationToken );
     }
 
 
     /// <inheritdoc />
-    public Task<ResendResponse> EventDeleteAsync( string eventIdOrName, CancellationToken cancellationToken = default )
+    public Task<ResendResponse<EventDeleteResult>> EventDeleteAsync( string eventIdOrName, CancellationToken cancellationToken = default )
     {
         var req = new HttpRequestMessage( HttpMethod.Delete, $"/events/{Uri.EscapeDataString( eventIdOrName )}" );
 
-        return Execute( req, cancellationToken );
+        return Execute<EventDeleteResult, EventDeleteResult>( req, ( x ) => x, cancellationToken );
     }
 
 

--- a/tests/Resend.Tests/ResendClientTests.Automations.cs
+++ b/tests/Resend.Tests/ResendClientTests.Automations.cs
@@ -21,7 +21,7 @@ public partial class ResendClientTests
                     Config = JsonDocument.Parse( "{\"event_name\":\"user.created\"}" ).RootElement,
                 },
             ],
-            Edges = [],
+            Connections = [],
         } );
 
         Assert.NotNull( resp );

--- a/tests/Resend.Tests/ResendClientTests.Events.cs
+++ b/tests/Resend.Tests/ResendClientTests.Events.cs
@@ -88,6 +88,7 @@ public partial class ResendClientTests
 
         Assert.NotNull( resp );
         Assert.True( resp.Success );
+        Assert.NotEqual( Guid.Empty, resp.Content );
     }
 
 
@@ -104,6 +105,7 @@ public partial class ResendClientTests
 
         Assert.NotNull( resp );
         Assert.True( resp.Success );
+        Assert.NotEqual( Guid.Empty, resp.Content );
     }
 
 
@@ -115,6 +117,7 @@ public partial class ResendClientTests
 
         Assert.NotNull( resp );
         Assert.True( resp.Success );
+        Assert.True( resp.Content.Deleted );
     }
 
 
@@ -122,10 +125,14 @@ public partial class ResendClientTests
     [Fact]
     public async Task EventDelete_ByGuid()
     {
-        var resp = await _resend.EventDeleteAsync( Guid.NewGuid() );
+        var id = Guid.NewGuid();
+
+        var resp = await _resend.EventDeleteAsync( id );
 
         Assert.NotNull( resp );
         Assert.True( resp.Success );
+        Assert.Equal( id, resp.Content.Id );
+        Assert.True( resp.Content.Deleted );
     }
 
 

--- a/tools/Resend.ApiServer/Controllers/AutomationController.cs
+++ b/tools/Resend.ApiServer/Controllers/AutomationController.cs
@@ -71,16 +71,18 @@ public class AutomationController : ControllerBase
             [
                 new AutomationStep()
                 {
+                    Key = stepA.ToString(),
                     Type = "trigger",
                     Config = JsonDocument.Parse( "{\"event_name\":\"user.created\"}" ).RootElement,
                 },
                 new AutomationStep()
                 {
+                    Key = stepB.ToString(),
                     Type = "send_email",
                     Config = JsonDocument.Parse( "{\"template_id\":\"tpl_xxxxxxxxx\",\"subject\":\"Welcome!\",\"from\":\"Acme <hello@example.com>\"}" ).RootElement,
                 },
             ],
-            Edges =
+            Connections =
             [
                 new AutomationEdge()
                 {
@@ -227,6 +229,7 @@ public class AutomationController : ControllerBase
             [
                 new AutomationRunStep()
                 {
+                    Key = "trigger-step",
                     Type = "trigger",
                     Status = "completed",
                     MomentStarted = DateTime.Parse( "2025-10-01 12:00:00.000000+00", null, System.Globalization.DateTimeStyles.RoundtripKind ),
@@ -237,6 +240,7 @@ public class AutomationController : ControllerBase
                 },
                 new AutomationRunStep()
                 {
+                    Key = "send-email-step",
                     Type = "send_email",
                     Status = "completed",
                     MomentStarted = DateTime.Parse( "2025-10-01 12:00:01.000000+00", null, System.Globalization.DateTimeStyles.RoundtripKind ),

--- a/tools/Resend.ApiServer/Controllers/EventController.cs
+++ b/tools/Resend.ApiServer/Controllers/EventController.cs
@@ -105,7 +105,13 @@ public class EventController : ControllerBase
     {
         _logger.LogDebug( "EventUpdate" );
 
-        return Ok();
+        var isGuid = Guid.TryParse( id, out var eid );
+
+        return Ok( new ObjectId()
+        {
+            Object = "event",
+            Id = isGuid ? eid : Guid.Parse( "a1b2c3d4-e5f6-7890-abcd-ef1234567890" ),
+        } );
     }
 
 
@@ -116,7 +122,14 @@ public class EventController : ControllerBase
     {
         _logger.LogDebug( "EventDelete" );
 
-        return Ok();
+        var isGuid = Guid.TryParse( id, out var eid );
+
+        return Ok( new EventDeleteResult()
+        {
+            Object = "event",
+            Id = isGuid ? eid : Guid.Parse( "a1b2c3d4-e5f6-7890-abcd-ef1234567890" ),
+            Deleted = true,
+        } );
     }
 
 


### PR DESCRIPTION
- Rename connections field from edges to connections (wire-level fix)
- Fix AutomationEdge connection type JSON property from edge_type to type
- Add missing key field to AutomationStep and AutomationRunStep response models
- Make started_at nullable on AutomationRun, AutomationRunSummary, AutomationRunStep
- Make updated_at nullable on EventResource
- Return ResendResponse<Guid> from EventUpdateAsync instead of empty response
- Add EventDeleteResult and return it from EventDeleteAsync

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align Events and Automations APIs with the latest OpenAPI spec to fix wire-level fields and return more useful responses. This includes renaming graph fields, making some timestamps nullable, and returning typed results for event update/delete.

- **Migration**
  - Automations graph: rename Edges to Connections on Automation, AutomationCreateData, and AutomationUpdateData. JSON field is now "connections".
  - Connection kind: JSON field is now "type" (was "edge_type"). Property remains EdgeType; no change unless you serialize custom JSON.
  - Step keys: new optional Key on AutomationStep and AutomationRunStep (no action needed).
  - Nullable timestamps: started_at on AutomationRun, AutomationRunSummary, AutomationRunStep and updated_at on EventResource are now nullable. Add null checks.
  - Events API:
    - EventUpdateAsync now returns ResendResponse<Guid> (the updated event ID).
    - EventDeleteAsync now returns ResendResponse<EventDeleteResult> with id and deleted.
    - Update call sites to use resp.Content accordingly.

<sup>Written for commit c27e436291908d118fa2e348be7e300775b9494a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

