### PR TITLE
feat(domains): add TrackingCAA record support

### DIFF
--- a/src/Resend/DomainRecord.cs
+++ b/src/Resend/DomainRecord.cs
@@ -7,7 +7,7 @@ public class DomainRecord
 {
     /// <summary />
     /// <remarks>
-    /// Example values: SPF, DKIM, Receiving, Tracking.
+    /// Example values: SPF, DKIM, Receiving, Tracking, TrackingCAA.
     /// </remarks>
     [JsonPropertyName( "record" )]
     public string Record { get; set; } = default!;

--- a/tests/Resend.Tests/DomainTests.cs
+++ b/tests/Resend.Tests/DomainTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Net.Http.Json;
 using System.Text.Json;
 
@@ -76,6 +77,55 @@ public class DomainTests
         Assert.NotNull( domain.Capabilities );
         Assert.Equal( "enabled", domain.Capabilities!.Sending );
         Assert.Equal( "disabled", domain.Capabilities.Receiving );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public void Domain_deserializes_tracking_caa_record()
+    {
+        const string json = """
+            {
+              "id": "d91cd9bd-1176-453e-8fc1-35364d380206",
+              "name": "example.com",
+              "status": "not_started",
+              "created_at": "2023-04-26T20:21:26.347412+00:00",
+              "region": "us-east-1",
+              "open_tracking": true,
+              "click_tracking": true,
+              "tracking_subdomain": "links",
+              "records": [
+                {
+                  "record": "Tracking",
+                  "name": "links.example.com",
+                  "value": "links1.resend-dns.com",
+                  "type": "CNAME",
+                  "ttl": "Auto",
+                  "status": "not_started"
+                },
+                {
+                  "record": "TrackingCAA",
+                  "name": "",
+                  "value": "0 issue \"amazon.com\"",
+                  "type": "CAA",
+                  "ttl": "Auto",
+                  "status": "verified"
+                }
+              ]
+            }
+            """;
+
+        var domain = JsonSerializer.Deserialize<Domain>( json );
+        Assert.NotNull( domain );
+        Assert.NotNull( domain!.Records );
+        Assert.Equal( 2, domain.Records!.Count );
+
+        var trackingCaa = domain.Records.Single( r => r.Record == "TrackingCAA" );
+        Assert.Equal( "", trackingCaa.Name );
+        Assert.Equal( "0 issue \"amazon.com\"", trackingCaa.Value );
+        Assert.Equal( "CAA", trackingCaa.RecordType );
+        Assert.Equal( "Auto", trackingCaa.TimeToLive );
+        Assert.Equal( ValidationStatus.Verified, trackingCaa.Status );
     }
 
 


### PR DESCRIPTION
## Summary

The Domains API now returns an additional DNS record on `POST /domains` and `GET /domains/:id` responses when:

1. A `tracking_subdomain` is configured on the domain, AND
2. The customer's root domain has CAA records that would otherwise prevent AWS from issuing a TLS certificate.

The new record looks like:

```json
{
  "record": "TrackingCAA",
  "name": "",
  "type": "CAA",
  "ttl": "Auto",
  "value": "0 issue \"amazon.com\"",
  "status": "verified"
}
```

`DomainRecord.Record` is already a free-form string so no source change is required for deserialization. This PR:

- Updates the xmldoc remark on `DomainRecord.Record` to list `TrackingCAA` as a possible value.
- Adds a `Domain_deserializes_tracking_caa_record` test that exercises both `Tracking` and `TrackingCAA` records end-to-end.

## Test plan

- [x] New unit test deserializes a domain payload containing both `Tracking` and `TrackingCAA` records and asserts every field
- [ ] CI runs full test suite

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for the `TrackingCAA` DNS record in Domains API responses when a tracking subdomain is set and existing CAA records would block AWS certificate issuance. No runtime changes needed; updated `DomainRecord.Record` remarks to include `TrackingCAA` and added a unit test that deserializes both `Tracking` and `TrackingCAA` records.

<sup>Written for commit f058726fcebe9591830fa83c72f28712510f5ade. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

