### PR TITLE
fix: add new domain statuses

### DIFF
--- a/src/Resend/Domain.cs
+++ b/src/Resend/Domain.cs
@@ -21,7 +21,7 @@ public class Domain
     /// Validation status.
     /// </summary>
     [JsonPropertyName( "status" )]
-    public ValidationStatus Status { get; set; }
+    public DomainStatus Status { get; set; }
 
     /// <summary>
     /// Moment when the domain was created.

--- a/src/Resend/DomainRecord.cs
+++ b/src/Resend/DomainRecord.cs
@@ -49,5 +49,5 @@ public class DomainRecord
     /// Validation status of individual DNS record.
     /// </summary>
     [JsonPropertyName( "status" )]
-    public ValidationStatus Status { get; set; }
+    public DomainRecordStatus Status { get; set; }
 }

--- a/src/Resend/DomainRecordStatus.cs
+++ b/src/Resend/DomainRecordStatus.cs
@@ -1,0 +1,49 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary />
+/// <see href="https://resend.com/docs/dashboard/domains/introduction#understand-a-domain-status" />
+/// <see href="https://github.com/resend/resend-node/blob/canary/src/domains/interfaces/domain.ts" />
+[JsonConverter( typeof( JsonStringEnumValueConverter<DomainRecordStatus> ) )]
+public enum DomainRecordStatus
+{
+    /// <summary>
+    /// Record validation hasn't been explicitly requested.
+    /// </summary>
+    [JsonStringValue( "not_started" )]
+    NotStarted,
+
+    /// <summary>
+    /// Record validation has been started and is currently executing.
+    /// </summary>
+    [JsonStringValue( "pending" )]
+    Pending,
+
+    /// <summary>
+    /// Record validation has failed: Resend was unable to detect the
+    /// necessary DNS record within 72h.
+    /// </summary>
+    [JsonStringValue( "failed" )]
+    Failed,
+
+    /// <summary>
+    /// Previously verified DNS record no longer resolves.
+    /// </summary>
+    /// <remarks>
+    /// For a previously verified record, Resend will periodically check for the DNS
+    /// record required for verification. If at some point, Resend is unable to detect
+    /// the record, the status would change to “<see cref="TemporaryFailure" />”. Resend will
+    /// recheck for the DNS record for 72 hours, and if it’s unable to detect the
+    /// record, the record status would change to “<see cref="Failed" />”. If it’s able to detect
+    /// the record, the record status would change to “<see cref="Verified"/>”.
+    /// </remarks>
+    [JsonStringValue( "temporary_failure" )]
+    TemporaryFailure,
+
+    /// <summary>
+    /// DNS record is successfully verified.
+    /// </summary>
+    [JsonStringValue( "verified" )]
+    Verified,
+}

--- a/src/Resend/DomainStatus.cs
+++ b/src/Resend/DomainStatus.cs
@@ -1,0 +1,56 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary />
+/// <see href="https://resend.com/docs/dashboard/domains/introduction#understand-a-domain-status" />
+/// <see href="https://github.com/resend/resend-node/blob/canary/src/domains/interfaces/domain.ts" />
+[JsonConverter( typeof( JsonStringEnumValueConverter<DomainStatus> ) )]
+public enum DomainStatus
+{
+    /// <summary>
+    /// Domain has been created, but validation hasn't been explicitly requested.
+    /// </summary>
+    /// <remarks>
+    /// Validation can be initiated by calling the <see cref="IResend.DomainVerifyAsync(Guid, CancellationToken)"/>
+    /// method.
+    /// </remarks>
+    [JsonStringValue( "not_started" )]
+    NotStarted,
+
+    /// <summary>
+    /// Validation has been started and is currently executing.
+    /// </summary>
+    /// <remarks>
+    /// May take up to 72h to conclude.
+    /// </remarks>
+    [JsonStringValue( "pending" )]
+    Pending,
+
+    /// <summary>
+    /// Validation has failed: Resend was unable to detect necessary DNS
+    /// records within 72h.
+    /// </summary>
+    [JsonStringValue( "failed" )]
+    Failed,
+
+    /// <summary>
+    /// Domain is successfully verified for sending in Resend.
+    /// </summary>
+    [JsonStringValue( "verified" )]
+    Verified,
+
+    /// <summary>
+    /// Domain is partially verified: some capabilities (for example,
+    /// sending) are verified while others are still pending.
+    /// </summary>
+    [JsonStringValue( "partially_verified" )]
+    PartiallyVerified,
+
+    /// <summary>
+    /// Domain is partially failed: some capabilities are verified while
+    /// others have failed validation.
+    /// </summary>
+    [JsonStringValue( "partially_failed" )]
+    PartiallyFailed,
+}

--- a/tests/Resend.Tests/DomainTests.cs
+++ b/tests/Resend.Tests/DomainTests.cs
@@ -125,7 +125,59 @@ public class DomainTests
         Assert.Equal( "0 issue \"amazon.com\"", trackingCaa.Value );
         Assert.Equal( "CAA", trackingCaa.RecordType );
         Assert.Equal( "Auto", trackingCaa.TimeToLive );
-        Assert.Equal( ValidationStatus.Verified, trackingCaa.Status );
+        Assert.Equal( DomainRecordStatus.Verified, trackingCaa.Status );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public void Domain_deserializes_partially_verified_status()
+    {
+        const string json = """
+            {
+              "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+              "name": "resend.com",
+              "status": "partially_verified",
+              "created_at": "2023-06-21T06:10:36.144Z",
+              "region": "us-east-1",
+              "click_tracking": true,
+              "tracking_subdomain": "track",
+              "capabilities": {
+                "sending": "enabled",
+                "receiving": "disabled"
+              },
+              "records": []
+            }
+            """;
+
+        var domain = JsonSerializer.Deserialize<Domain>( json );
+        Assert.NotNull( domain );
+        Assert.Equal( DomainStatus.PartiallyVerified, domain!.Status );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public void Domain_deserializes_partially_failed_status()
+    {
+        const string json = """
+            {
+              "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+              "name": "resend.com",
+              "status": "partially_failed",
+              "created_at": "2023-06-21T06:10:36.144Z",
+              "region": "us-east-1",
+              "capabilities": {
+                "sending": "enabled",
+                "receiving": "enabled"
+              },
+              "records": []
+            }
+            """;
+
+        var domain = JsonSerializer.Deserialize<Domain>( json );
+        Assert.NotNull( domain );
+        Assert.Equal( DomainStatus.PartiallyFailed, domain!.Status );
     }
 
 

--- a/tools/Resend.ApiServer/Controllers/DomainController.cs
+++ b/tools/Resend.ApiServer/Controllers/DomainController.cs
@@ -29,7 +29,7 @@ public class DomainController : ControllerBase
             Id = Guid.NewGuid(),
             Name = "example.com",
             Region = DeliveryRegion.UsEast1,
-            Status = ValidationStatus.NotStarted,
+            Status = DomainStatus.NotStarted,
             MomentCreated = DateTime.UtcNow,
             Records = new List<DomainRecord>()
             {
@@ -39,7 +39,7 @@ public class DomainController : ControllerBase
                     RecordType = "TXT",
                     Name = "bounces",
                     TimeToLive = "Auto",
-                    Status = ValidationStatus.NotStarted,
+                    Status = DomainRecordStatus.NotStarted,
                     Value = "feedback-smtp.us-east-1.amazonses.com",
                 },
             },
@@ -59,7 +59,7 @@ public class DomainController : ControllerBase
             Id = id,
             Name = "example.com",
             Region = DeliveryRegion.UsEast1,
-            Status = ValidationStatus.NotStarted,
+            Status = DomainStatus.NotStarted,
             MomentCreated = DateTime.UtcNow,
             Records = new List<DomainRecord>()
             {
@@ -69,7 +69,7 @@ public class DomainController : ControllerBase
                     RecordType = "TXT",
                     Name = "bounces",
                     TimeToLive = "Auto",
-                    Status = ValidationStatus.NotStarted,
+                    Status = DomainRecordStatus.NotStarted,
                     Value = "feedback-smtp.us-east-1.amazonses.com",
                 },
             },
@@ -123,7 +123,7 @@ public class DomainController : ControllerBase
                     Id = Guid.NewGuid(),
                     Name = "example.com",
                     Region = DeliveryRegion.UsEast1,
-                    Status = ValidationStatus.NotStarted,
+                    Status = DomainStatus.NotStarted,
                     MomentCreated = DateTime.UtcNow,
                 },
                 new Domain()
@@ -131,7 +131,7 @@ public class DomainController : ControllerBase
                     Id = Guid.NewGuid(),
                     Name = "amazing.com",
                     Region = DeliveryRegion.EuWest1,
-                    Status = ValidationStatus.Pending,
+                    Status = DomainStatus.Pending,
                     MomentCreated = DateTime.UtcNow,
                 }
             },


### PR DESCRIPTION
## Summary

Add two new domain-level statuses — `partially_verified` and `partially_failed` — and split the status typing so they apply only to domains, not individual DNS records.

- New enum `DomainStatus` (domain-level): `not_started | pending | failed | verified | partially_verified | partially_failed`
- New enum `DomainRecordStatus` (record-level): `not_started | pending | failed | temporary_failure | verified`
- `Domain.Status` now typed as `DomainStatus`
- `DomainRecord.Status` now typed as `DomainRecordStatus`
- `ValidationStatus` is kept for webhook payloads (`DomainEventData`) — webhook schema is out of scope for this change

Adds two deserialization tests covering `partially_verified` and `partially_failed`. Also updates the `Resend.ApiServer` mock controller to use the new enums.

Matches resend/resend-node#936.

## Breaking change note

`Domain.Status` and `DomainRecord.Status` property types have changed. Consumers that assigned or compared these against `ValidationStatus` values will need to update to the new enum types.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two new domain statuses and split status enums by scope to align with the Resend API. This changes the types of `Domain.Status` and `DomainRecord.Status`.

- **New Features**
  - Added `DomainStatus` with `partially_verified` and `partially_failed`.
  - Added `DomainRecordStatus` (includes `temporary_failure`).
  - `Domain.Status` now uses `DomainStatus`; `DomainRecord.Status` uses `DomainRecordStatus`.
  - Kept `ValidationStatus` for webhook payloads only.
  - Added deserialization tests for the new domain statuses.
  - Updated `Resend.ApiServer` mock controller to use the new enums.

- **Migration**
  - Replace any uses of `ValidationStatus` for `Domain.Status` and `DomainRecord.Status` with `DomainStatus` and `DomainRecordStatus`.
  - No changes needed for webhook handling (`ValidationStatus` remains).

<sup>Written for commit 0636f78827894d0ee9bcf923f9d2e99a51ed778e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

