### PR TITLE
feat: add RESEND_API_KEY environment variable support

### DIFF
--- a/src/Resend/ResendClient.cs
+++ b/src/Resend/ResendClient.cs
@@ -38,8 +38,13 @@ public partial class ResendClient : IResend
          */
         var opt = options.Value;
 
+        var apiToken = opt.ApiToken;
+
+        if ( string.IsNullOrWhiteSpace( apiToken ) )
+            apiToken = Environment.GetEnvironmentVariable( "RESEND_API_KEY" );
+
         httpClient.BaseAddress = new Uri( opt.ApiUrl );
-        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue( "Bearer", opt.ApiToken );
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue( "Bearer", apiToken );
 
 
         /*
@@ -736,5 +741,28 @@ public partial class ResendClient : IResend
         opt.ApiToken = apiToken;
 
         return Create( opt );
+    }
+
+
+    /// <summary>
+    /// Creates an instance of Resend using the RESEND_API_KEY environment variable.
+    /// </summary>
+    /// <returns>Instance of Resend client.</returns>
+    /// <remarks>
+    /// Utility method for examples/one-off apps. Requires the RESEND_API_KEY
+    /// environment variable to be set. For most use-cases it is preferable to use
+    /// dependency injection to configure/inject `IResend` instances.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when RESEND_API_KEY environment variable is not set.
+    /// </exception>
+    public static IResend Create()
+    {
+        var apiToken = Environment.GetEnvironmentVariable( "RESEND_API_KEY" );
+
+        if ( string.IsNullOrWhiteSpace( apiToken ) )
+            throw new InvalidOperationException( "Missing API key. Pass it to the constructor `ResendClient.Create(\"re_123\")` or set the RESEND_API_KEY environment variable." );
+
+        return Create( apiToken );
     }
 }

--- a/tests/Resend.Tests/ResendClientCreateTests.cs
+++ b/tests/Resend.Tests/ResendClientCreateTests.cs
@@ -1,0 +1,60 @@
+namespace Resend.Tests;
+
+public class ResendClientCreateTests
+{
+    [Fact]
+    public void Create_WithApiToken_Succeeds()
+    {
+        var client = ResendClient.Create( "re_test_123" );
+
+        Assert.NotNull( client );
+    }
+
+
+    [Fact]
+    public void Create_NoArg_WithEnvVar_Succeeds()
+    {
+        Environment.SetEnvironmentVariable( "RESEND_API_KEY", "re_env_123" );
+
+        try
+        {
+            var client = ResendClient.Create();
+
+            Assert.NotNull( client );
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable( "RESEND_API_KEY", null );
+        }
+    }
+
+
+    [Fact]
+    public void Create_WithOptions_NoApiToken_EnvVarFallback_Succeeds()
+    {
+        Environment.SetEnvironmentVariable( "RESEND_API_KEY", "re_env_123" );
+
+        try
+        {
+            var opt = new ResendClientOptions();
+            var client = ResendClient.Create( opt );
+
+            Assert.NotNull( client );
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable( "RESEND_API_KEY", null );
+        }
+    }
+
+
+    [Fact]
+    public void Create_NoArg_NoEnvVar_ThrowsInvalidOperationException()
+    {
+        Environment.SetEnvironmentVariable( "RESEND_API_KEY", null );
+
+        var ex = Assert.Throws<InvalidOperationException>( () => ResendClient.Create() );
+
+        Assert.Contains( "RESEND_API_KEY", ex.Message );
+    }
+}


### PR DESCRIPTION
- Constructor now falls back to RESEND_API_KEY env var when ApiToken is not set. 
- New ResendClient.Create() no-arg factory reads the env var and throws InvalidOperationException if absent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
ResendClient now falls back to the RESEND_API_KEY environment variable when ApiToken isn’t set. Also adds a no-arg ResendClient.Create() that reads the env var and throws if missing.

- **New Features**
  - Constructor uses RESEND_API_KEY if ApiToken is empty.
  - Added ResendClient.Create() that reads RESEND_API_KEY; throws InvalidOperationException when absent.
  - Tests cover env fallback, no-arg success, and error case.

<sup>Written for commit 6b0e17a16cae90d5aa00946d456cbc44ab14d9de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

