### PR TITLE
Change webhook validator to read asynchronously

### DIFF
--- a/src/Resend.Webhooks/WebhookSink.cs
+++ b/src/Resend.Webhooks/WebhookSink.cs
@@ -17,12 +17,13 @@ public class WebhookSink<T>
         HttpRequest request,
         [FromServices] ILogger<WebhookSink<T>> logger,
         [FromServices] T handler,
-        [FromServices] WebhookValidator validator )
+        [FromServices] WebhookValidator validator,
+        CancellationToken cancellationToken = default )
     {
         /*
          * 
          */
-        var ctx = validator.Validate( request );
+        var ctx = await validator.ValidateAsync( request, cancellationToken );
 
 
         /*

--- a/src/Resend.Webhooks/WebhookValidator.cs
+++ b/src/Resend.Webhooks/WebhookValidator.cs
@@ -21,7 +21,7 @@ public class WebhookValidator
 
 
     /// <summary />
-    public WebhookContext Validate( HttpRequest request )
+    public async Task<WebhookContext> ValidateAsync( HttpRequest request, CancellationToken cancellationToken = default )
     {
         /*
          * 
@@ -46,7 +46,7 @@ public class WebhookValidator
 
             try
             {
-                s.Payload = reader.ReadToEnd();
+                s.Payload = await reader.ReadToEndAsync( cancellationToken );
             }
             catch
             {

--- a/src/Resend.Webhooks/WebhookValidator.cs
+++ b/src/Resend.Webhooks/WebhookValidator.cs
@@ -48,7 +48,7 @@ public class WebhookValidator
             {
                 s.Payload = await reader.ReadToEndAsync( cancellationToken );
             }
-            catch
+            catch ( Exception e ) when ( e is not OperationCanceledException )
             {
                 s.Exception = new WebhookException( "RWH002", "Unable to read raw body" );
 


### PR DESCRIPTION
Resolves #106 by changing the payload read to `await StreamReader.ReadToEndAsync()`. This required changing the method to asynchronous and returning a `Task<WebhookContext>` instead.

Also added cancellation token for the request to the webhook sink delegate so that it can be passed to the validator stream read.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make webhook validation async to avoid blocking during payload reads and to support request cancellation. Adds `CancellationToken` flow and renames `Validate` to `ValidateAsync` (closes #106).

- **Refactors**
  - Read request payload with `await ReadToEndAsync(cancellationToken)`; ignore `OperationCanceledException`.
  - Rename `WebhookValidator.Validate(HttpRequest)` to `ValidateAsync(HttpRequest, CancellationToken)` returning `Task<WebhookContext>`.
  - `WebhookSink` now passes the request `CancellationToken` to the validator.

- **Migration**
  - Replace `validator.Validate(request)` with `await validator.ValidateAsync(request, cancellationToken)` and make callers async.

<sup>Written for commit 82461f7935b22174f10229e89a3ba40e4b27d0d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

