### PR TITLE
Add 2 missing email webhook event types

### DIFF
--- a/src/Resend/WebhookEventType.cs
+++ b/src/Resend/WebhookEventType.cs
@@ -90,7 +90,7 @@ public enum WebhookEventType
     /// on the suppression list.
     /// See https://www.resend.com/docs/knowledge-base/why-are-my-emails-landing-on-the-suppression-list
     /// </remarks>
-    [JsonStringValue( "email.suppressed")]
+    [JsonStringValue( "email.suppressed" )]
     EmailSuppressed,
 
 

--- a/src/Resend/WebhookEventType.cs
+++ b/src/Resend/WebhookEventType.cs
@@ -76,6 +76,23 @@ public enum WebhookEventType
     [JsonStringValue( "email.failed" )]
     EmailFailed,
 
+    /// <summary>
+    /// Email was scheduled to be sent at some point in the future.
+    /// </summary>
+    [JsonStringValue( "email.scheduled" )]
+    EmailScheduled,
+
+    /// <summary>
+    /// The sending of this email was suppressed.
+    /// </summary>
+    /// <remarks>
+    /// This event is triggered when an email is sent to an address
+    /// on the suppression list.
+    /// See https://www.resend.com/docs/knowledge-base/why-are-my-emails-landing-on-the-suppression-list
+    /// </remarks>
+    [JsonStringValue( "email.suppressed")]
+    EmailSuppressed,
+
 
     /// <summary>
     /// A contact was successfully created.


### PR DESCRIPTION
Resolves #108 by adding `email.scheduled` and `email.suppressed` to the WebhookEventType enumeration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `email.scheduled` and `email.suppressed` to `WebhookEventType` so apps can handle scheduled and suppressed email webhooks, aligning with Resend’s event catalog and avoiding deserialization errors; includes a minor formatting fix.

<sup>Written for commit 9e2522ec7202401566bdf7b711872061a4ea1b8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

