### PR TITLE
Updating webhook data fields

### DIFF
--- a/src/Resend.Webhooks/ContactEventData.cs
+++ b/src/Resend.Webhooks/ContactEventData.cs
@@ -10,6 +10,11 @@ public class ContactEventData : IWebhookData
     public Guid ContactId { get; set; }
 
     /// <summary />
+    [JsonPropertyName( "audience_id" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? AudienceId { get; set; }
+
+    /// <summary />
     [JsonPropertyName( "segment_ids" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
     public List<Guid>? SegmentIds { get; set; }

--- a/src/Resend.Webhooks/EmailEventAttachment.cs
+++ b/src/Resend.Webhooks/EmailEventAttachment.cs
@@ -1,0 +1,27 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Resend.Webhooks;
+
+/// <summary />
+public class EmailEventAttachment
+{
+    /// <summary />
+    [JsonPropertyName( "id" )]
+    public Guid Id { get; set; }
+
+    /// <summary />
+    [JsonPropertyName( "filename" )]
+    public string Filename { get; set; } = default!;
+
+    /// <summary />
+    [JsonPropertyName( "content_type" )]
+    public string ContentType { get; set; } = default!;
+
+    /// <summary />
+    [JsonPropertyName( "content_disposition" )]
+    public string ContentDisposition { get; set; } = default!;
+
+    /// <summary />
+    [JsonPropertyName( "content_id" )]
+    public string ContentId { get; set; } = default!;
+}

--- a/src/Resend.Webhooks/EmailEventData.cs
+++ b/src/Resend.Webhooks/EmailEventData.cs
@@ -23,6 +23,30 @@ public class EmailEventData : IWebhookData
     public EmailAddressList To { get; set; } = default!;
 
     /// <summary />
+    /// <remarks>
+    /// Only set for <see cref="WebhookEventType.EmailReceived" />, otherwise is null.
+    /// </remarks>
+    [JsonPropertyName( "bcc" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public EmailAddressList? Bcc { get; set; } = default!;
+
+    /// <summary />
+    /// <remarks>
+    /// Only set for <see cref="WebhookEventType.EmailReceived" />, otherwise is null.
+    /// </remarks>
+    [JsonPropertyName( "cc" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public EmailAddressList? Cc { get; set; } = default!;
+
+    /// <summary />
+    /// <remarks>
+    /// Only set for <see cref="WebhookEventType.EmailReceived" />, otherwise is null.
+    /// </remarks>
+    [JsonPropertyName( "message_id" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? MessageId { get; set; }
+
+    /// <summary />
     [JsonPropertyName( "subject" )]
     public string Subject { get; set; } = default!;
 
@@ -40,6 +64,14 @@ public class EmailEventData : IWebhookData
     [JsonPropertyName( "tags" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
     public Dictionary<string, string>? Tags { get; set; }
+
+    /// <summary />
+    /// <remarks>
+    /// Only set for <see cref="WebhookEventType.EmailReceived" />, otherwise is null.
+    /// </remarks>
+    [JsonPropertyName( "attachments" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public List<EmailEventAttachment>? Attachments { get; set; }
 
     /// <summary />
     /// <remarks>

--- a/src/Resend.Webhooks/EmailEventData.cs
+++ b/src/Resend.Webhooks/EmailEventData.cs
@@ -61,6 +61,14 @@ public class EmailEventData : IWebhookData
     [JsonPropertyName( "failed" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull  )]
     public EmailFailedData? Failed { get; set; }
+
+    /// <summary />
+    /// <remarks>
+    /// Only set for <see cref="WebhookEventType.EmailSuppressed"/>
+    /// </remarks>
+    [JsonPropertyName( "suppressed" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public EmailFailedData? Suppressed { get; set; }
 }
 
 
@@ -104,10 +112,25 @@ public class EmailClickData
     public string UserAgent { get; set; } = default!;
 }
 
+
 /// <summary />
 public class EmailFailedData
 {
     /// <summary />
     [JsonPropertyName( "reason" )]
     public string Reason { get; set; } = default!;
+}
+
+
+/// <summary />
+public class EmailSuppressedData
+{
+    /// <summary />
+    [JsonPropertyName( "message" )]
+    public string Message { get; set; } = default!;
+
+    /// <summary />
+    /// <remarks>TODO: What are the possible values?</remarks>
+    [JsonPropertyName( "type" )]
+    public string Type { get; set; } = default!; 
 }

--- a/src/Resend.Webhooks/EmailEventData.cs
+++ b/src/Resend.Webhooks/EmailEventData.cs
@@ -28,14 +28,17 @@ public class EmailEventData : IWebhookData
 
     /// <summary />
     [JsonPropertyName( "broadcast_id" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
     public string? BroadcastId { get; set; }
 
     /// <summary />
     [JsonPropertyName( "template_id" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
     public string? TemplateId { get; set; }
 
     /// <summary />
     [JsonPropertyName( "tags" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
     public Dictionary<string, string>? Tags { get; set; }
 
     /// <summary />
@@ -68,7 +71,7 @@ public class EmailEventData : IWebhookData
     /// </remarks>
     [JsonPropertyName( "suppressed" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-    public EmailFailedData? Suppressed { get; set; }
+    public EmailSuppressedData? Suppressed { get; set; }
 }
 
 

--- a/src/Resend.Webhooks/EmailEventData.cs
+++ b/src/Resend.Webhooks/EmailEventData.cs
@@ -123,7 +123,12 @@ public class EmailBounceData
     /// <remarks>TODO: What are the possible values?</remarks>
     [JsonPropertyName( "type" )]
     public string Type { get; set; } = default!;
-}
+
+    /// <summary />
+    [JsonPropertyName( "diagnosticCode" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public List<string>? DiagnosticCode { get; set; }
+} 
 
 
 /// <summary />

--- a/src/Resend.Webhooks/EmailEventData.cs
+++ b/src/Resend.Webhooks/EmailEventData.cs
@@ -27,6 +27,18 @@ public class EmailEventData : IWebhookData
     public string Subject { get; set; } = default!;
 
     /// <summary />
+    [JsonPropertyName( "broadcast_id" )]
+    public string? BroadcastId { get; set; }
+
+    /// <summary />
+    [JsonPropertyName( "template_id" )]
+    public string? TemplateId { get; set; }
+
+    /// <summary />
+    [JsonPropertyName( "tags" )]
+    public Dictionary<string, string>? Tags { get; set; }
+
+    /// <summary />
     /// <remarks>
     /// Only set for <see cref="WebhookEventType.EmailClicked" />, otherwise is null.
     /// </remarks>
@@ -41,6 +53,14 @@ public class EmailEventData : IWebhookData
     [JsonPropertyName( "bounce" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
     public EmailBounceData? Bounce { get; set; }
+
+    /// <summary />
+    /// <remarks>
+    /// Only set for <see cref="WebhookEventType.EmailFailed"/>
+    /// </remarks>
+    [JsonPropertyName( "failed" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull  )]
+    public EmailFailedData? Failed { get; set; }
 }
 
 
@@ -82,4 +102,12 @@ public class EmailClickData
     /// <summary />
     [JsonPropertyName( "userAgent" )]
     public string UserAgent { get; set; } = default!;
+}
+
+/// <summary />
+public class EmailFailedData
+{
+    /// <summary />
+    [JsonPropertyName( "reason" )]
+    public string Reason { get; set; } = default!;
 }


### PR DESCRIPTION
Start work on #105. Added some fields to the email event data payload object and the audience id to contact event data.

Creating as a draft as there is more info needed to complete this (see #105 for discussion).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update webhook payload models to match the latest Resend schema. Email events add inbound fields (`bcc`, `cc`, `message_id`, `attachments`) and new metadata (`broadcast_id`, `template_id`, `tags`, `failed.reason`, `suppressed.{message,type}`, `bounce.diagnosticCode`), and contact events add `audience_id`; all new fields are optional and ignored when null via JsonIgnore, and `suppressed.type` is fixed.

<sup>Written for commit c55cc5527853f6b4049a5372316a5093043afa58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

