### PR TITLE
fix: Add 'Suppressed' status to EmailStatus enum

### DIFF
--- a/src/Resend/EmailStatus.cs
+++ b/src/Resend/EmailStatus.cs
@@ -72,6 +72,12 @@ public enum EmailStatus
     Scheduled,
 
     /// <summary>
+    /// Email is suppressed.
+    /// </summary>
+    [JsonStringValue( "suppressed" )]
+    Suppressed,
+
+    /// <summary>
     /// Email delivery failed.
     /// </summary>
     [JsonStringValue( "failed" )]


### PR DESCRIPTION
This pull request adds a new status to the `EmailStatus` enum to better represent the state of suppressed emails.

Enhancements to email status tracking:

* Added a new `Suppressed` value to the `EmailStatus` enum, with a corresponding JSON string value of `"suppressed"`, to indicate when an email is suppressed.

- fixes #113 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a `Suppressed` status to the `EmailStatus` enum to represent suppressed emails. Serialized as `"suppressed"` so clients can detect and handle suppression events correctly.

<sup>Written for commit ef248bc59881b08e3534a6197b94fe08de1a082b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

