### PR TITLE
chore(ci): harden security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,29 +1,33 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
       - '**'
-    pull_request:
-      branches:
-        - '**'
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
       - name: Setup .NET SDK 8.0
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: '8.0.x'
 
       - name: Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          path: 
-            .nuget
-          key: nuget
+          path: .nuget
+          key: nuget-${{ hashFiles('**/*.csproj','**/packages.lock.json') }}
 
       - name: Run ci.sh
         run: ./cicd/ci.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,27 +3,32 @@ name: Release
 on:
   push:
     tags:
-    - '*.*.*'
+      - '*.*.*'
 
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
       - name: Setup .NET SDK 8.0
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: '8.0.x'
 
       - name: Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          path:
-            .nuget
-          key: nuget
+          path: .nuget
+          key: nuget-${{ hashFiles('**/*.csproj','**/packages.lock.json') }}
 
       - name: Run release.sh
         run: ./cicd/release.sh


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened GitHub Actions for `resend-dotnet` by pinning actions, scoping NuGet cache keys, and adding least-privilege permissions, timeouts, and release concurrency. Addresses Linear DEV-655.

- **Refactors**
  - Pinned `actions/checkout`, `actions/setup-dotnet`, and `actions/cache` to SHAs.
  - Scoped NuGet cache with `key: nuget-${{ hashFiles('**/*.csproj','**/packages.lock.json') }}` and `path: .nuget`.
  - Added `permissions: contents: read` at the CI workflow level; kept `contents: write` for release.
  - Added `timeout-minutes: 30` to CI and Release jobs and `concurrency` for Release to prevent parallel publishes.

<sup>Written for commit e492c508cc28c8dfaf9e6c0dd00b3563769bd005. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

