### PR TITLE
Add Package Manager Console installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Install
 > dotnet add package Resend
 ```
 
+```
+PM> Install-Package Resend
+```
+
 
 Examples
 --------------------------------------------------------------------------


### PR DESCRIPTION
Updated the README to include the Package Manager Console command for the Resend NuGet package. 

While the .NET CLI is standard for many, providing the PM Console  alternative helps the onboarding experience for developers  working primarily within the Visual Studio IDE.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the Package Manager Console command `Install-Package Resend` to the README so Visual Studio users can install the `Resend` NuGet package easily. This sits alongside the `.NET CLI` example for smoother onboarding.

<sup>Written for commit 111456921133ee710e18b31552ee4e91c8f54d95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

