### PR TITLE
Fix webhook payload deserialize

### DIFF
--- a/src/Resend.Webhooks/Json/WebhookEventConverter.cs
+++ b/src/Resend.Webhooks/Json/WebhookEventConverter.cs
@@ -33,13 +33,14 @@ public class WebhookEventConverter : JsonConverter<WebhookEvent>
         /*
          * 
          */
-        reader.Read();
 
         JsonElement rawData = default;
 
         // Read the 3 properties
         for ( int i = 0; i < 3; i++ )
         {
+            reader.Read();
+
             if ( reader.TokenType != JsonTokenType.PropertyName )
                 throw new JsonException( "Expected PropertyName" );
 
@@ -147,16 +148,6 @@ public class WebhookEventConverter : JsonConverter<WebhookEvent>
         //{
         //    throw new NotSupportedException( $"Unexpected '{value.EventType}' event type" );
         //}
-
-        reader.Read();
-
-        if ( reader.TokenType != JsonTokenType.PropertyName )
-            throw new JsonException( "Expected PropertyName" );
-
-        if ( reader.GetString() != "data" )
-            throw new JsonException( "Expected 'data' property" );
-
-        reader.Read();
 
         if ( category == WebhookEventTypeCategory.Email )
         {

--- a/src/Resend.Webhooks/Json/WebhookEventConverter.cs
+++ b/src/Resend.Webhooks/Json/WebhookEventConverter.cs
@@ -35,14 +35,46 @@ public class WebhookEventConverter : JsonConverter<WebhookEvent>
          */
         reader.Read();
 
-        if ( reader.TokenType != JsonTokenType.PropertyName )
-            throw new JsonException( "Expected PropertyName" );
+        JsonElement rawData = default;
 
-        if ( reader.GetString() != "type" )
-            throw new JsonException( "Expected 'type' property" );
+        // Read the 3 properties
+        for ( int i = 0; i < 3; i++ )
+        {
+            if ( reader.TokenType != JsonTokenType.PropertyName )
+                throw new JsonException( "Expected PropertyName" );
 
-        reader.Read();
-        value.EventType = _wet.Read( ref reader, typeof( WebhookEventType ), options );
+            string? propertyName = reader.GetString();
+
+            if ( propertyName == "type" )
+            {
+                reader.Read();
+                value.EventType = _wet.Read( ref reader, typeof( WebhookEventType ), options );
+            }
+            else if ( propertyName == "created_at" )
+            {
+                reader.Read();
+                value.MomentCreated = _utc.Read( ref reader, typeof( DateTime ), options );
+            }
+            else if ( propertyName == "data" )
+            {
+                reader.Read();
+                rawData = JsonElement.ParseValue( ref reader );
+            }
+            else
+            {
+                throw new JsonException( "Invalid property name" );
+            }
+        }
+
+
+
+        
+
+        //if ( reader.GetString() != "type" )
+        //    throw new JsonException( "Expected 'type' property" );
+
+        //reader.Read();
+        //value.EventType = _wet.Read( ref reader, typeof( WebhookEventType ), options );
 
         var category = value.EventType.Category();
 
@@ -50,21 +82,72 @@ public class WebhookEventConverter : JsonConverter<WebhookEvent>
         /*
          * 
          */
-        reader.Read();
+        //reader.Read();
 
-        if ( reader.TokenType != JsonTokenType.PropertyName )
-            throw new JsonException( "Expected PropertyName" );
+        //if ( reader.TokenType != JsonTokenType.PropertyName )
+        //    throw new JsonException( "Expected PropertyName" );
 
-        if ( reader.GetString() != "created_at" )
-            throw new JsonException( "Expected 'created_at' property" );
+        //if ( reader.GetString() != "created_at" )
+        //    throw new JsonException( "Expected 'created_at' property" );
 
-        reader.Read();
-        value.MomentCreated = _utc.Read( ref reader, typeof( DateTime ), options );
+        //reader.Read();
+        //value.MomentCreated = _utc.Read( ref reader, typeof( DateTime ), options );
 
 
         /*
          * 
          */
+        //reader.Read();
+
+        //if ( reader.TokenType != JsonTokenType.PropertyName )
+        //    throw new JsonException( "Expected PropertyName" );
+
+        //if ( reader.GetString() != "data" )
+        //    throw new JsonException( "Expected 'data' property" );
+
+        //reader.Read();
+
+        //if ( category == WebhookEventTypeCategory.Email )
+        //{
+        //    var t1 = typeof( EmailEventData );
+        //    var o1 = (JsonConverter<EmailEventData>) options.GetConverter( t1 );
+
+        //    var data = o1.Read( ref reader, t1, options );
+
+        //    if ( data == null )
+        //        throw new JsonException( "Expected non-null data" );
+
+        //    value.Data = data;
+        //}
+        //else if ( category == WebhookEventTypeCategory.Contact )
+        //{
+        //    var t2 = typeof( ContactEventData );
+        //    var o2 = (JsonConverter<ContactEventData>) options.GetConverter( t2 );
+
+        //    var data = o2.Read( ref reader, t2, options );
+
+        //    if ( data == null )
+        //        throw new JsonException( "Expected non-null data" );
+
+        //    value.Data = data;
+        //}
+        //else if ( category == WebhookEventTypeCategory.Domain )
+        //{
+        //    var t3 = typeof( DomainEventData );
+        //    var o2 = (JsonConverter<DomainEventData>) options.GetConverter( t3 );
+
+        //    var data = o2.Read( ref reader, t3, options );
+
+        //    if ( data == null )
+        //        throw new JsonException( "Expected non-null data" );
+
+        //    value.Data = data;
+        //}
+        //else
+        //{
+        //    throw new NotSupportedException( $"Unexpected '{value.EventType}' event type" );
+        //}
+
         reader.Read();
 
         if ( reader.TokenType != JsonTokenType.PropertyName )
@@ -77,10 +160,7 @@ public class WebhookEventConverter : JsonConverter<WebhookEvent>
 
         if ( category == WebhookEventTypeCategory.Email )
         {
-            var t1 = typeof( EmailEventData );
-            var o1 = (JsonConverter<EmailEventData>) options.GetConverter( t1 );
-
-            var data = o1.Read( ref reader, t1, options );
+            var data = rawData.Deserialize<EmailEventData>( options );
 
             if ( data == null )
                 throw new JsonException( "Expected non-null data" );
@@ -89,10 +169,7 @@ public class WebhookEventConverter : JsonConverter<WebhookEvent>
         }
         else if ( category == WebhookEventTypeCategory.Contact )
         {
-            var t2 = typeof( ContactEventData );
-            var o2 = (JsonConverter<ContactEventData>) options.GetConverter( t2 );
-
-            var data = o2.Read( ref reader, t2, options );
+            var data = rawData.Deserialize<ContactEventData>( options );
 
             if ( data == null )
                 throw new JsonException( "Expected non-null data" );
@@ -101,10 +178,7 @@ public class WebhookEventConverter : JsonConverter<WebhookEvent>
         }
         else if ( category == WebhookEventTypeCategory.Domain )
         {
-            var t3 = typeof( DomainEventData );
-            var o2 = (JsonConverter<DomainEventData>) options.GetConverter( t3 );
-
-            var data = o2.Read( ref reader, t3, options );
+            var data = rawData.Deserialize<DomainEventData>( options );
 
             if ( data == null )
                 throw new JsonException( "Expected non-null data" );

--- a/src/Resend.Webhooks/Json/WebhookEventConverter.cs
+++ b/src/Resend.Webhooks/Json/WebhookEventConverter.cs
@@ -33,6 +33,10 @@ public class WebhookEventConverter : JsonConverter<WebhookEvent>
         /*
          * 
          */
+        bool hasType = false;
+        bool hasCreatedAt = false;
+        bool hasData = false;
+
         JsonElement rawData = default;
 
         // Read the 3 webhook payload properties
@@ -47,16 +51,31 @@ public class WebhookEventConverter : JsonConverter<WebhookEvent>
 
             if ( propertyName == "type" )
             {
+                if ( hasType )
+                    throw new JsonException( "Duplicate 'type' property" );
+
+                hasType = true;
+
                 reader.Read();
                 value.EventType = _wet.Read( ref reader, typeof( WebhookEventType ), options );
             }
             else if ( propertyName == "created_at" )
             {
+                if ( hasCreatedAt )
+                    throw new JsonException( "Duplicate 'created_at' property" );
+
+                hasCreatedAt = true;
+
                 reader.Read();
                 value.MomentCreated = _utc.Read( ref reader, typeof( DateTime ), options );
             }
             else if ( propertyName == "data" )
             {
+                if ( hasData )
+                    throw new JsonException( "Duplicate 'data' property" );
+
+                hasData = true;
+
                 reader.Read();
                 rawData = JsonElement.ParseValue( ref reader );
             }
@@ -66,7 +85,10 @@ public class WebhookEventConverter : JsonConverter<WebhookEvent>
             }
         }
 
-        
+        if ( !hasType || !hasCreatedAt || !hasData )
+            throw new JsonException( "Missing required webhook properties" );
+
+
         /*
          * 
          */

--- a/src/Resend.Webhooks/Json/WebhookEventConverter.cs
+++ b/src/Resend.Webhooks/Json/WebhookEventConverter.cs
@@ -33,10 +33,9 @@ public class WebhookEventConverter : JsonConverter<WebhookEvent>
         /*
          * 
          */
-
         JsonElement rawData = default;
 
-        // Read the 3 properties
+        // Read the 3 webhook payload properties
         for ( int i = 0; i < 3; i++ )
         {
             reader.Read();
@@ -67,88 +66,16 @@ public class WebhookEventConverter : JsonConverter<WebhookEvent>
             }
         }
 
-
-
         
-
-        //if ( reader.GetString() != "type" )
-        //    throw new JsonException( "Expected 'type' property" );
-
-        //reader.Read();
-        //value.EventType = _wet.Read( ref reader, typeof( WebhookEventType ), options );
-
+        /*
+         * 
+         */
         var category = value.EventType.Category();
 
 
         /*
          * 
          */
-        //reader.Read();
-
-        //if ( reader.TokenType != JsonTokenType.PropertyName )
-        //    throw new JsonException( "Expected PropertyName" );
-
-        //if ( reader.GetString() != "created_at" )
-        //    throw new JsonException( "Expected 'created_at' property" );
-
-        //reader.Read();
-        //value.MomentCreated = _utc.Read( ref reader, typeof( DateTime ), options );
-
-
-        /*
-         * 
-         */
-        //reader.Read();
-
-        //if ( reader.TokenType != JsonTokenType.PropertyName )
-        //    throw new JsonException( "Expected PropertyName" );
-
-        //if ( reader.GetString() != "data" )
-        //    throw new JsonException( "Expected 'data' property" );
-
-        //reader.Read();
-
-        //if ( category == WebhookEventTypeCategory.Email )
-        //{
-        //    var t1 = typeof( EmailEventData );
-        //    var o1 = (JsonConverter<EmailEventData>) options.GetConverter( t1 );
-
-        //    var data = o1.Read( ref reader, t1, options );
-
-        //    if ( data == null )
-        //        throw new JsonException( "Expected non-null data" );
-
-        //    value.Data = data;
-        //}
-        //else if ( category == WebhookEventTypeCategory.Contact )
-        //{
-        //    var t2 = typeof( ContactEventData );
-        //    var o2 = (JsonConverter<ContactEventData>) options.GetConverter( t2 );
-
-        //    var data = o2.Read( ref reader, t2, options );
-
-        //    if ( data == null )
-        //        throw new JsonException( "Expected non-null data" );
-
-        //    value.Data = data;
-        //}
-        //else if ( category == WebhookEventTypeCategory.Domain )
-        //{
-        //    var t3 = typeof( DomainEventData );
-        //    var o2 = (JsonConverter<DomainEventData>) options.GetConverter( t3 );
-
-        //    var data = o2.Read( ref reader, t3, options );
-
-        //    if ( data == null )
-        //        throw new JsonException( "Expected non-null data" );
-
-        //    value.Data = data;
-        //}
-        //else
-        //{
-        //    throw new NotSupportedException( $"Unexpected '{value.EventType}' event type" );
-        //}
-
         if ( category == WebhookEventTypeCategory.Email )
         {
             var data = rawData.Deserialize<EmailEventData>( options );

--- a/src/Resend/ResendExtensions.cs
+++ b/src/Resend/ResendExtensions.cs
@@ -25,8 +25,12 @@ public static class ResendExtensions
             case WebhookEventType.EmailComplained:
             case WebhookEventType.EmailDelivered:
             case WebhookEventType.EmailDeliveryDelay:
+            case WebhookEventType.EmailFailed:
             case WebhookEventType.EmailOpened:
+            case WebhookEventType.EmailReceived:
+            case WebhookEventType.EmailScheduled:
             case WebhookEventType.EmailSent:
+            case WebhookEventType.EmailSuppressed:
                 return WebhookEventTypeCategory.Email;
 
             default:


### PR DESCRIPTION
Resolves #107 by changing the deserialization logic in the WebhookEventHandler.

Currently the webhook payloads coming from Resend have the properties in a different order than the docs show and the converter is designed to parse. Further complicating things is the fact that the event type is required to know how to parse the data field, but the type comes *after* the data.

To fix this, the new converter loads the properties (in any order) and temporarily stores the webhook data as a JsonElement. After all of the fields are parsed, the JsonElement is deserialized into the correct type for the webhook.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix webhook payload deserialization so events are parsed correctly even when fields arrive out of order, with stricter validation. Resolves #107.

- **Bug Fixes**
  - Read `type`, `created_at`, and `data` in any order with checks for duplicates, missing fields, and unknown properties in `WebhookEventConverter`.
  - Buffer `data` as `JsonElement`, then deserialize after the event type is known.
  - Map missing email event types in `WebhookEventTypeCategory`: `EmailFailed`, `EmailReceived`, `EmailScheduled`, `EmailSuppressed`.

<sup>Written for commit de11f4650336eacb9c6ceac931e0a96c5a4a12c5. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/resend-dotnet/pull/118?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

