### PR TITLE
Add missing fields

### DIFF
--- a/src/Resend/EmailReceipt.cs
+++ b/src/Resend/EmailReceipt.cs
@@ -68,6 +68,13 @@ public class EmailReceipt
     public string? HtmlBody { get; set; }
 
     /// <summary>
+    /// Email tags.
+    /// </summary>
+    [JsonPropertyName( "tags" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public List<EmailTag>? Tags { get; set; }
+
+    /// <summary>
     /// Moment for which the email is scheduled for/at.
     /// </summary>
     [JsonPropertyName( "scheduled_at" )]

--- a/src/Resend/EmailStatus.cs
+++ b/src/Resend/EmailStatus.cs
@@ -72,6 +72,12 @@ public enum EmailStatus
     Scheduled,
 
     /// <summary>
+    /// Email has been sent.
+    /// </summary>
+    [JsonStringValue( "sent" )]
+    Sent,
+
+    /// <summary>
     /// Email is suppressed.
     /// </summary>
     [JsonStringValue( "suppressed" )]


### PR DESCRIPTION
Add missing Email Status "Sent" and missing "Tags" field to Email Receipt.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing EmailStatus "sent" and the "tags" field on EmailReceipt to align with the Resend API. This enables clients to read tag metadata and the sent status from receipts.

- **New Features**
  - Added EmailStatus.Sent mapped to JSON value "sent".
  - Added EmailReceipt.Tags: List<EmailTag>? serialized as "tags".

<sup>Written for commit 82d10e4ca0abb534167bde8f2fd16dc064aee7a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

