### PR TITLE
Add message_id to EmailReceipt and EmailEventData

### DIFF
--- a/src/Resend.Webhooks/EmailEventData.cs
+++ b/src/Resend.Webhooks/EmailEventData.cs
@@ -14,6 +14,13 @@ public class EmailEventData : IWebhookData
     [JsonPropertyName( "email_id" )]
     public Guid EmailId { get; set; }
 
+    /// <summary>
+    /// RFC Message-ID header value for the email.
+    /// </summary>
+    [JsonPropertyName( "message_id" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? MessageId { get; set; }
+
     /// <summary />
     [JsonPropertyName( "from" )]
     public EmailAddress From { get; set; } = default!;

--- a/src/Resend/EmailReceipt.cs
+++ b/src/Resend/EmailReceipt.cs
@@ -52,6 +52,13 @@ public class EmailReceipt
     [JsonPropertyName( "subject" )]
     public string Subject { get; set; } = default!;
 
+    /// <summary>
+    /// RFC Message-ID header value for the email.
+    /// </summary>
+    [JsonPropertyName( "message_id" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? MessageId { get; set; }
+
 
     /// <summary>
     /// The plain text version of the message.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `message_id` typing to match the Resend API and Node.js SDK:

- **`EmailReceipt`** — `GET /emails/:id` (and list) responses
- **`EmailEventData`** — email webhook payloads

`ReceivedEmail` already had `MessageId` for the receiving API.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0585ee5-f83c-451c-8086-72494e5a6d7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0585ee5-f83c-451c-8086-72494e5a6d7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the RFC Message-ID on email receipts and webhook events in the .NET SDK to match the Resend API and Node.js SDK for easier cross-system correlation.

- **New Features**
  - Add nullable `MessageId` (maps to `message_id`) to `EmailReceipt` for `GET /emails/:id` and list responses.
  - Add nullable `MessageId` to `EmailEventData` for all email webhooks (e.g., `email.sent`, `email.delivered`, `email.received`).

<sup>Written for commit a633bdc5026a8f966ee149fc3b518f2dc3dfe3fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

