### PR TITLE
Fix duplicate MessageId in EmailEventData breaking build

### DIFF
--- a/src/Resend.Webhooks/EmailEventData.cs
+++ b/src/Resend.Webhooks/EmailEventData.cs
@@ -46,14 +46,6 @@ public class EmailEventData : IWebhookData
     public EmailAddressList? Cc { get; set; } = default!;
 
     /// <summary />
-    /// <remarks>
-    /// Only set for <see cref="WebhookEventType.EmailReceived" />, otherwise is null.
-    /// </remarks>
-    [JsonPropertyName( "message_id" )]
-    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-    public string? MessageId { get; set; }
-
-    /// <summary />
     [JsonPropertyName( "subject" )]
     public string Subject { get; set; } = default!;
 


### PR DESCRIPTION
## Problem

`main` has been failing to build since #112 merged (`build: failure` on the merge commit).

`EmailEventData` contains **two** `MessageId` properties → `error CS0102: the type 'EmailEventData' already contains a definition for 'MessageId'`.

## Root cause

Two separately-merged PRs each added a `message_id` property to `EmailEventData`:
- #123 added `MessageId` near the top of the class.
- #112 added `MessageId` again in its inbound block.

The insertions were at different line ranges, so git merged both with **no textual conflict** — but the result is a semantically invalid class with a duplicate member. #112's PR CI was green in isolation; the **post-merge** CI run on `main` went red and wasn't caught.

## Fix

Remove #112's duplicate, keep #123's. #123's is in the correct common position with an accurate summary; #112's also carried a misleading `Only set for EmailReceived` remark (the server sends `message_id` for outbound events too), so dropping it fixes an inaccuracy as well.

## Verification

Local build + full test suite on .NET 8 (matching CI): **build succeeds, 122/122 tests pass**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a build failure by removing the duplicate MessageId property from EmailEventData. Keeps the canonical property and removes the incorrect “only set for EmailReceived” remark, since the server sends message_id for both inbound and outbound events.

<sup>Written for commit 0fca7ab9c4cbdbb2d94c4b543a93e0d327a5aee1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

