### PR TITLE
Type template id as string to allow aliases (#119)

### DIFF
--- a/src/Resend/EmailMessageTemplate.cs
+++ b/src/Resend/EmailMessageTemplate.cs
@@ -6,10 +6,10 @@ namespace Resend;
 public class EmailMessageTemplate
 {
     /// <summary>
-    /// Identifier of published template.
+    /// Identifier or alias of the published template.
     /// </summary>
     [JsonPropertyName( "id" )]
-    public Guid TemplateId { get; set; }
+    public string TemplateId { get; set; } = default!;
 
     /// <summary>
     /// Template variables.

--- a/tests/Resend.Tests/EmailMessageTemplateTests.cs
+++ b/tests/Resend.Tests/EmailMessageTemplateTests.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+
+namespace Resend.Tests;
+
+/// <summary />
+public class EmailMessageTemplateTests
+{
+    /// <summary />
+    [Fact]
+    public void SerializesAliasId()
+    {
+        var message = new EmailMessage()
+        {
+            From = "from@example.com",
+            To = "to@example.com",
+            Template = new EmailMessageTemplate() { TemplateId = "welcome-email" },
+        };
+
+        var json = JsonSerializer.Serialize( message );
+
+        Assert.Contains( "\"id\":\"welcome-email\"", json );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public void RoundtripsAliasId()
+    {
+        var template = new EmailMessageTemplate() { TemplateId = "welcome-email" };
+
+        var json = JsonSerializer.Serialize( template );
+        var actual = JsonSerializer.Deserialize<EmailMessageTemplate>( json );
+
+        Assert.NotNull( actual );
+        Assert.Equal( "welcome-email", actual.TemplateId );
+    }
+}


### PR DESCRIPTION
Resolves #119.

## Problem
`EmailMessageTemplate.TemplateId` (the `template.id` sent with an email) was typed as `Guid`. The send-email API accepts **either a UUID or a user-assigned alias string** for `template.id` (server validates `z.union([z.guid(), z.string().max(54)])`). Typing it as `Guid` makes it impossible to send a hosted template identified by its alias.

## Fix
Change `TemplateId` from `Guid` to `string`, which accepts both a UUID and an alias. This only affects the send path; the template-management APIs (retrieve/update/delete/publish/duplicate) keep their `Guid` id and their existing `string` alias overloads.

## Verification
Build + full suite on .NET 8: **117/117 pass** (2 new serialization tests for alias ids).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow sending templates by alias by changing `EmailMessageTemplate.TemplateId` to a string. The send API now accepts both UUID and alias values for `template.id`.

- **Migration**
  - Update usages of `EmailMessageTemplate.TemplateId` to `string` (use `guid.ToString()` if needed).
  - Template-management APIs are unchanged (still `Guid` id with existing alias overloads).

<sup>Written for commit 6483688ab76599a70b7b71577e038b874a56adee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

