### PR TITLE
Allow omitting Subject and From for hosted-template sends (#117)

### DIFF
--- a/src/Resend/EmailMessage.cs
+++ b/src/Resend/EmailMessage.cs
@@ -10,8 +10,13 @@ public class EmailMessage
     /// <summary>
     /// Sender email address.
     /// </summary>
+    /// <remarks>
+    /// Can be omitted when sending a hosted <see cref="Template" /> that
+    /// defines a default sender.
+    /// </remarks>
     [JsonPropertyName( "from" )]
-    public EmailAddress From { get; set; } = default!;
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public EmailAddress? From { get; set; }
 
     /// <summary>
     /// Recipient email address (list).
@@ -22,8 +27,13 @@ public class EmailMessage
     /// <summary>
     /// Email subject.
     /// </summary>
+    /// <remarks>
+    /// Can be omitted when sending a hosted <see cref="Template" /> that
+    /// defines a default subject.
+    /// </remarks>
     [JsonPropertyName( "subject" )]
-    public string Subject { get; set; } = default!;
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? Subject { get; set; }
 
     /// <summary>
     /// Cc/carbon-copy recipient email address.

--- a/tests/Resend.Tests/EmailMessageTests.cs
+++ b/tests/Resend.Tests/EmailMessageTests.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+
+namespace Resend.Tests;
+
+/// <summary />
+public class EmailMessageTests
+{
+    /// <summary />
+    [Fact]
+    public void OmitsSubjectAndFromWhenNull()
+    {
+        var message = new EmailMessage()
+        {
+            To = "to@example.com",
+        };
+
+        var json = JsonSerializer.Serialize( message );
+
+        Assert.DoesNotContain( "\"subject\"", json );
+        Assert.DoesNotContain( "\"from\"", json );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public void IncludesSubjectAndFromWhenSet()
+    {
+        var message = new EmailMessage()
+        {
+            From = "from@example.com",
+            To = "to@example.com",
+            Subject = "Hello",
+        };
+
+        var json = JsonSerializer.Serialize( message );
+
+        Assert.Contains( "\"subject\":\"Hello\"", json );
+        Assert.Contains( "\"from\"", json );
+    }
+}


### PR DESCRIPTION
Resolves #117.

## Problem
`EmailMessage.Subject` and `EmailMessage.From` are non-nullable and lack `JsonIgnore`, so they are **always** serialized. When sending a hosted template, the API allows omitting `subject`/`from` to use the template's defaults (server validation only requires them when `template.id` is absent). Today the SDK can't cleanly omit them — sending `subject: null` risks a validation error.

## Fix
Make `Subject` and `From` nullable with `[JsonIgnore(Condition = WhenWritingNull)]`, so they're omitted from the payload when unset.

**Scope note:** #117 names only `Subject`, but `From` has the identical problem and a template send needs *both* omittable, so this includes `From` too. Happy to split it out if you'd prefer the PR mirror the issue exactly.

No regression for normal sends: a missing subject was already rejected server-side and still is — this only changes `null` from `"subject": null` to omitted.

## Verification
Build + full suite on .NET 8: **117/117 pass** (2 new serialization tests: omitted-when-null, present-when-set).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows omitting Subject and From when sending a hosted template. This matches the API and uses template defaults instead of sending null values.

- **Bug Fixes**
  - Made Subject and From nullable with JsonIgnore(WhenWritingNull) so they’re excluded from JSON when unset; normal sends remain server-validated.
  - Added serialization tests for omit-when-null and include-when-set.

<sup>Written for commit b962801bf5fe8d612493ce78894cb65414ba70e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

