### PR TITLE
Add remaining missing webhook email data fields (#105)

### DIFF
--- a/src/Resend.Webhooks/EmailEventAttachment.cs
+++ b/src/Resend.Webhooks/EmailEventAttachment.cs
@@ -7,21 +7,24 @@ public class EmailEventAttachment
 {
     /// <summary />
     [JsonPropertyName( "id" )]
-    public Guid Id { get; set; }
-
-    /// <summary />
-    [JsonPropertyName( "filename" )]
-    public string Filename { get; set; } = default!;
+    public string Id { get; set; } = default!;
 
     /// <summary />
     [JsonPropertyName( "content_type" )]
     public string ContentType { get; set; } = default!;
 
     /// <summary />
+    [JsonPropertyName( "filename" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? Filename { get; set; }
+
+    /// <summary />
     [JsonPropertyName( "content_disposition" )]
-    public string ContentDisposition { get; set; } = default!;
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? ContentDisposition { get; set; }
 
     /// <summary />
     [JsonPropertyName( "content_id" )]
-    public string ContentId { get; set; } = default!;
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? ContentId { get; set; }
 }

--- a/src/Resend.Webhooks/EmailEventData.cs
+++ b/src/Resend.Webhooks/EmailEventData.cs
@@ -46,8 +46,23 @@ public class EmailEventData : IWebhookData
     public EmailAddressList? Cc { get; set; } = default!;
 
     /// <summary />
+    /// <remarks>
+    /// Only set for <see cref="WebhookEventType.EmailReceived" />, otherwise is null.
+    /// </remarks>
+    [JsonPropertyName( "received_for" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public EmailAddressList? ReceivedFor { get; set; }
+
+    /// <summary />
     [JsonPropertyName( "subject" )]
     public string Subject { get; set; } = default!;
+
+    /// <summary>
+    /// Custom headers included on the email.
+    /// </summary>
+    [JsonPropertyName( "headers" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public List<EmailEventHeader>? Headers { get; set; }
 
     /// <summary />
     [JsonPropertyName( "broadcast_id" )]
@@ -79,6 +94,14 @@ public class EmailEventData : IWebhookData
     [JsonPropertyName( "click" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
     public EmailClickData? Click { get; set; }
+
+    /// <summary />
+    /// <remarks>
+    /// Only set for <see cref="WebhookEventType.EmailOpened" />, otherwise is null.
+    /// </remarks>
+    [JsonPropertyName( "open" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public EmailOpenData? Open { get; set; }
 
     /// <summary />
     /// <remarks>
@@ -153,6 +176,24 @@ public class EmailClickData
 
 
 /// <summary />
+public class EmailOpenData
+{
+    /// <summary />
+    [JsonPropertyName( "ipAddress" )]
+    public string IpAddress { get; set; } = default!;
+
+    /// <summary />
+    [JsonPropertyName( "timestamp" )]
+    [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
+    public DateTime MomentOpened { get; set; }
+
+    /// <summary />
+    [JsonPropertyName( "userAgent" )]
+    public string UserAgent { get; set; } = default!;
+}
+
+
+/// <summary />
 public class EmailFailedData
 {
     /// <summary />
@@ -169,7 +210,18 @@ public class EmailSuppressedData
     public string Message { get; set; } = default!;
 
     /// <summary />
-    /// <remarks>TODO: What are the possible values?</remarks>
+    /// <remarks>One of "Suppressed" or "OnAccountSuppressionList".</remarks>
     [JsonPropertyName( "type" )]
-    public string Type { get; set; } = default!; 
+    public string Type { get; set; } = default!;
+
+    /// <summary />
+    /// <remarks>One of "previous_bounce" or "previous_complaint".</remarks>
+    [JsonPropertyName( "reason" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? Reason { get; set; }
+
+    /// <summary />
+    [JsonPropertyName( "diagnosticCode" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public List<string>? DiagnosticCode { get; set; }
 }

--- a/src/Resend.Webhooks/EmailEventHeader.cs
+++ b/src/Resend.Webhooks/EmailEventHeader.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace Resend.Webhooks;
+
+/// <summary>
+/// Custom header included on an email event.
+/// </summary>
+public class EmailEventHeader
+{
+    /// <summary />
+    [JsonPropertyName( "name" )]
+    public string Name { get; set; } = default!;
+
+    /// <summary />
+    [JsonPropertyName( "value" )]
+    public string Value { get; set; } = default!;
+}

--- a/tests/Resend.Webhooks.Tests/WebhookDataFieldsTests.cs
+++ b/tests/Resend.Webhooks.Tests/WebhookDataFieldsTests.cs
@@ -1,0 +1,129 @@
+using System.Text.Json;
+
+namespace Resend.Webhooks.Tests;
+
+/// <summary />
+public class WebhookDataFieldsTests
+{
+    /// <summary />
+    [Fact]
+    public void EmailOpenedDeserializesOpenAndHeaders()
+    {
+        var json = """
+        {
+          "type": "email.opened",
+          "created_at": "2024-11-22T23:41:12.126Z",
+          "data": {
+            "created_at": "2024-11-22T23:41:11.894Z",
+            "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
+            "from": "onboarding@resend.dev",
+            "to": [ "delivered@resend.dev" ],
+            "subject": "Sending this example",
+            "headers": [ { "name": "X-Entity-Ref-ID", "value": "abc-123" } ],
+            "open": { "ipAddress": "1.2.3.4", "timestamp": "2024-11-22T23:41:12.126Z", "userAgent": "Mozilla/5.0" }
+          }
+        }
+        """;
+
+        var evt = JsonSerializer.Deserialize<WebhookEvent>( json );
+
+        Assert.NotNull( evt );
+        Assert.Equal( WebhookEventType.EmailOpened, evt.EventType );
+
+        var data = evt.DataAs<EmailEventData>();
+
+        Assert.NotNull( data.Open );
+        Assert.Equal( "1.2.3.4", data.Open!.IpAddress );
+        Assert.Equal( "Mozilla/5.0", data.Open.UserAgent );
+
+        Assert.NotNull( data.Headers );
+        Assert.Single( data.Headers );
+        Assert.Equal( "X-Entity-Ref-ID", data.Headers![ 0 ].Name );
+        Assert.Equal( "abc-123", data.Headers[ 0 ].Value );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public void EmailReceivedDeserializesInboundFields()
+    {
+        var json = """
+        {
+          "type": "email.received",
+          "created_at": "2024-11-22T23:41:12.126Z",
+          "data": {
+            "created_at": "2024-11-22T23:41:11.894Z",
+            "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
+            "from": "sender@example.com",
+            "to": [ "inbox@example.com" ],
+            "subject": "Inbound",
+            "message_id": "<abc@mail.example.com>",
+            "bcc": [],
+            "cc": [ "copy@example.com" ],
+            "received_for": [ "inbox@example.com" ],
+            "attachments": [ {
+              "id": "att_123",
+              "content_type": "image/png",
+              "content_disposition": "inline",
+              "filename": "avatar.png",
+              "content_id": "img001"
+            } ]
+          }
+        }
+        """;
+
+        var evt = JsonSerializer.Deserialize<WebhookEvent>( json );
+
+        Assert.NotNull( evt );
+        Assert.Equal( WebhookEventType.EmailReceived, evt.EventType );
+
+        var data = evt.DataAs<EmailEventData>();
+
+        Assert.Equal( "<abc@mail.example.com>", data.MessageId );
+        Assert.NotNull( data.ReceivedFor );
+        Assert.Single( data.ReceivedFor! );
+        Assert.NotNull( data.Attachments );
+        Assert.Single( data.Attachments! );
+        Assert.Equal( "att_123", data.Attachments![ 0 ].Id );
+        Assert.Equal( "avatar.png", data.Attachments[ 0 ].Filename );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public void EmailSuppressedDeserializesAllFields()
+    {
+        var json = """
+        {
+          "type": "email.suppressed",
+          "created_at": "2024-11-22T23:41:12.126Z",
+          "data": {
+            "created_at": "2024-11-22T23:41:11.894Z",
+            "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
+            "from": "sender@example.com",
+            "to": [ "suppressed@example.com" ],
+            "subject": "Suppressed",
+            "suppressed": {
+              "message": "recipient is on the account suppression list",
+              "type": "OnAccountSuppressionList",
+              "reason": "previous_bounce",
+              "diagnosticCode": [ "smtp; 550 5.1.1 user unknown" ]
+            }
+          }
+        }
+        """;
+
+        var evt = JsonSerializer.Deserialize<WebhookEvent>( json );
+
+        Assert.NotNull( evt );
+        Assert.Equal( WebhookEventType.EmailSuppressed, evt.EventType );
+
+        var data = evt.DataAs<EmailEventData>();
+
+        Assert.NotNull( data.Suppressed );
+        Assert.Equal( "OnAccountSuppressionList", data.Suppressed!.Type );
+        Assert.Equal( "previous_bounce", data.Suppressed.Reason );
+        Assert.NotNull( data.Suppressed.DiagnosticCode );
+        Assert.Single( data.Suppressed.DiagnosticCode! );
+    }
+}


### PR DESCRIPTION
Closes #105.

Completes `EmailEventData` parity with the Resend webhook payload. Field shapes verified against the server assembly (`monorepo/apps/email-events-webhooks-consumer/src/utils/call-webhook.ts`) and the OpenAPI spec. #112 added several fields but left these out:

## New fields
- **`open`** (`EmailOpenData`: `ipAddress`, `timestamp`, `userAgent`) — set for `email.opened`. Mirrors `EmailClickData` without `link`. This was the most notable gap — opens are common and the payload was previously dropped.
- **`headers`** (`List<EmailEventHeader>`) — custom headers, present on every email event (inbound and outbound). Sent by the server as an array of `{name, value}`.
- **`received_for`** (`EmailAddressList`) — inbound `email.received` only.
- **`suppressed.reason`** and **`suppressed.diagnosticCode`** — the server sends `{message, type, reason, diagnosticCode}`; #112 modeled only `message` + `type`.

## Corrections to #112's attachment model
- `EmailEventAttachment.Id`: **`Guid` → `string`**. The server types it as a plain string and inbound attachment ids are not UUIDs; `Guid` would throw at deserialization. (The new inbound test uses `"att_123"` to cover this.)
- `filename`, `content_disposition`, `content_id` made nullable to match the server (`string | null`).

## Tests
3 new raw-JSON deserialization tests in `Resend.Webhooks.Tests` (real server-style payloads for opened, received, suppressed). Full suite on .NET 8: **all pass** (Webhooks 6/6).

## Note
`suppressed.reason`/`type` are modeled as `string` (documented enum values in remarks) rather than enums, consistent with the existing `bounce.type`/`subType` treatment in this file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes `EmailEventData` parity with the Resend webhook payload and fixes attachment modeling to match the API. Ensures open events, headers, inbound recipients, and suppression details deserialize correctly.

- **New Features**
  - `open` (`EmailOpenData`: `ipAddress`, `timestamp`, `userAgent`) for `email.opened`.
  - `headers` (`List<EmailEventHeader>`) on all events.
  - `received_for` (`EmailAddressList`) for inbound `email.received`.
  - `suppressed.reason` and `suppressed.diagnosticCode`.

- **Bug Fixes**
  - `EmailEventAttachment.Id`: `Guid` → `string` to prevent deserialization errors.
  - `filename`, `content_disposition`, `content_id` are now nullable to match the server.
  - Added raw JSON deserialization tests for opened, received, and suppressed events.

<sup>Written for commit 55ebbba1a3c0c244c8bd4e995869b1c44a8bbea4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

