### PR TITLE
Add OAuth grants support (list + revoke)

### DIFF
--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -358,12 +358,15 @@ public interface IResend
     /// <summary>
     /// Lists all OAuth grants.
     /// </summary>
+    /// <param name="query">
+    /// Pagination query.
+    /// </param>
     /// <param name="cancellationToken">
     /// Cancellation token.
     /// </param>
-    /// <returns>List of OAuth grants.</returns>
+    /// <returns>Paginated list of OAuth grants.</returns>
     /// <see href="https://resend.com/docs/api-reference/oauth/list-grants"/>
-    Task<ResendResponse<List<OAuthGrant>>> OAuthGrantListAsync( CancellationToken cancellationToken = default );
+    Task<ResendResponse<PaginatedResult<OAuthGrant>>> OAuthGrantListAsync( PaginatedQuery? query = null, CancellationToken cancellationToken = default );
 
     /// <summary>
     /// Revoke an existing OAuth grant. Revoking a grant invalidates every access

--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -353,6 +353,36 @@ public interface IResend
 
     #endregion
 
+    #region OAuth Grants
+
+    /// <summary>
+    /// Lists all OAuth grants.
+    /// </summary>
+    /// <param name="cancellationToken">
+    /// Cancellation token.
+    /// </param>
+    /// <returns>List of OAuth grants.</returns>
+    /// <see href="https://resend.com/docs/api-reference/oauth/list-grants"/>
+    Task<ResendResponse<List<OAuthGrant>>> OAuthGrantListAsync( CancellationToken cancellationToken = default );
+
+    /// <summary>
+    /// Revoke an existing OAuth grant. Revoking a grant invalidates every access
+    /// and refresh token issued under it.
+    /// </summary>
+    /// <param name="oauthGrantId">
+    /// OAuth grant identifier.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Cancellation token.
+    /// </param>
+    /// <returns>
+    /// Outcome of the revocation.
+    /// </returns>
+    /// <see href="https://resend.com/docs/api-reference/oauth/revoke-grant"/>
+    Task<ResendResponse<OAuthGrantRevoked>> OAuthGrantRevokeAsync( Guid oauthGrantId, CancellationToken cancellationToken = default );
+
+    #endregion
+
     #region Audiences
 
     /// <summary>

--- a/src/Resend/OAuthGrant.cs
+++ b/src/Resend/OAuthGrant.cs
@@ -1,0 +1,108 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// OAuth grant, representing access a user has delegated to an OAuth client.
+/// </summary>
+public class OAuthGrant
+{
+    /// <summary>
+    /// OAuth grant identifier.
+    /// </summary>
+    [JsonPropertyName( "id" )]
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Identifier of the OAuth client the grant was issued to.
+    /// </summary>
+    [JsonPropertyName( "client_id" )]
+    public Guid ClientId { get; set; }
+
+    /// <summary>
+    /// Scopes granted to the OAuth client.
+    /// </summary>
+    [JsonPropertyName( "scopes" )]
+    public List<string> Scopes { get; set; } = default!;
+
+    /// <summary>
+    /// Resource the grant is restricted to, if any.
+    /// </summary>
+    [JsonPropertyName( "resource" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? Resource { get; set; }
+
+    /// <summary>
+    /// Moment in which the grant was created.
+    /// </summary>
+    [JsonPropertyName( "created_at" )]
+    [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
+    public DateTime MomentCreated { get; set; }
+
+    /// <summary>
+    /// Moment in which the grant was revoked, if it has been revoked.
+    /// </summary>
+    [JsonPropertyName( "revoked_at" )]
+    [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public DateTime? MomentRevoked { get; set; }
+
+    /// <summary>
+    /// Reason the grant was revoked, if it has been revoked.
+    /// </summary>
+    [JsonPropertyName( "revoked_reason" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? RevokedReason { get; set; }
+
+    /// <summary>
+    /// OAuth client the grant was issued to.
+    /// </summary>
+    [JsonPropertyName( "client" )]
+    public OAuthGrantClient Client { get; set; } = default!;
+}
+
+
+/// <summary>
+/// OAuth client associated with a grant.
+/// </summary>
+public class OAuthGrantClient
+{
+    /// <summary>
+    /// Display name of the OAuth client.
+    /// </summary>
+    [JsonPropertyName( "name" )]
+    public string Name { get; set; } = default!;
+
+    /// <summary>
+    /// URI of the OAuth client logo, if any.
+    /// </summary>
+    [JsonPropertyName( "logo_uri" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? LogoUri { get; set; }
+}
+
+
+/// <summary>
+/// Outcome of revoking an OAuth grant.
+/// </summary>
+public class OAuthGrantRevoked
+{
+    /// <summary>
+    /// OAuth grant identifier.
+    /// </summary>
+    [JsonPropertyName( "id" )]
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Moment in which the grant was revoked.
+    /// </summary>
+    [JsonPropertyName( "revoked_at" )]
+    [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
+    public DateTime MomentRevoked { get; set; }
+
+    /// <summary>
+    /// Reason the grant was revoked.
+    /// </summary>
+    [JsonPropertyName( "revoked_reason" )]
+    public string RevokedReason { get; set; } = default!;
+}

--- a/src/Resend/OAuthGrant.cs
+++ b/src/Resend/OAuthGrant.cs
@@ -88,6 +88,12 @@ public class OAuthGrantClient
 public class OAuthGrantRevoked
 {
     /// <summary>
+    /// Object type discriminator.
+    /// </summary>
+    [JsonPropertyName( "object" )]
+    public string Object { get; set; } = default!;
+
+    /// <summary>
     /// OAuth grant identifier.
     /// </summary>
     [JsonPropertyName( "id" )]

--- a/src/Resend/ResendClient.OAuthGrants.cs
+++ b/src/Resend/ResendClient.OAuthGrants.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.WebUtilities;
 using Resend.Payloads;
 
 namespace Resend;
@@ -5,12 +6,30 @@ namespace Resend;
 public partial class ResendClient
 {
     /// <inheritdoc />
-    public Task<ResendResponse<List<OAuthGrant>>> OAuthGrantListAsync( CancellationToken cancellationToken = default )
+    public Task<ResendResponse<PaginatedResult<OAuthGrant>>> OAuthGrantListAsync( PaginatedQuery? query = null, CancellationToken cancellationToken = default )
     {
-        var path = $"/oauth/grants";
-        var req = new HttpRequestMessage( HttpMethod.Get, path );
+        var baseUrl = "/oauth/grants";
+        var url = baseUrl;
 
-        return Execute<ListOf<OAuthGrant>, List<OAuthGrant>>( req, ( x ) => x.Data, cancellationToken );
+        if ( query != null )
+        {
+            var qs = new Dictionary<string, string?>();
+
+            if ( query.Limit.HasValue == true )
+                qs.Add( "limit", query.Limit.Value.ToString() );
+
+            if ( query.Before != null )
+                qs.Add( "before", query.Before );
+
+            if ( query.After != null )
+                qs.Add( "after", query.After );
+
+            url = QueryHelpers.AddQueryString( baseUrl, qs );
+        }
+
+        var req = new HttpRequestMessage( HttpMethod.Get, url );
+
+        return Execute<PaginatedResult<OAuthGrant>, PaginatedResult<OAuthGrant>>( req, ( x ) => x, cancellationToken );
     }
 
 

--- a/src/Resend/ResendClient.OAuthGrants.cs
+++ b/src/Resend/ResendClient.OAuthGrants.cs
@@ -1,0 +1,25 @@
+using Resend.Payloads;
+
+namespace Resend;
+
+public partial class ResendClient
+{
+    /// <inheritdoc />
+    public Task<ResendResponse<List<OAuthGrant>>> OAuthGrantListAsync( CancellationToken cancellationToken = default )
+    {
+        var path = $"/oauth/grants";
+        var req = new HttpRequestMessage( HttpMethod.Get, path );
+
+        return Execute<ListOf<OAuthGrant>, List<OAuthGrant>>( req, ( x ) => x.Data, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
+    public Task<ResendResponse<OAuthGrantRevoked>> OAuthGrantRevokeAsync( Guid oauthGrantId, CancellationToken cancellationToken = default )
+    {
+        var path = $"/oauth/grants/{oauthGrantId}";
+        var req = new HttpRequestMessage( HttpMethod.Delete, path );
+
+        return Execute<OAuthGrantRevoked, OAuthGrantRevoked>( req, ( x ) => x, cancellationToken );
+    }
+}

--- a/tests/Resend.Tests/ResendClientTests.OAuthGrants.cs
+++ b/tests/Resend.Tests/ResendClientTests.OAuthGrants.cs
@@ -1,0 +1,37 @@
+namespace Resend.Tests;
+
+/// <summary />
+public partial class ResendClientTests
+{
+    /// <summary />
+    [Fact]
+    public async Task OAuthGrantList()
+    {
+        var resp = await _resend.OAuthGrantListAsync();
+
+        Assert.NotNull( resp );
+        Assert.NotNull( resp.Content );
+        Assert.NotEmpty( resp.Content );
+
+        var grant = resp.Content[ 0 ];
+
+        Assert.NotEqual( Guid.Empty, grant.Id );
+        Assert.Equal( "Resend CLI", grant.Client.Name );
+        Assert.Contains( "emails:send", grant.Scopes );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task OAuthGrantRevoke()
+    {
+        var id = Guid.NewGuid();
+
+        var resp = await _resend.OAuthGrantRevokeAsync( id );
+
+        Assert.NotNull( resp );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( id, resp.Content.Id );
+        Assert.Equal( "revoked_from_api", resp.Content.RevokedReason );
+    }
+}

--- a/tests/Resend.Tests/ResendClientTests.OAuthGrants.cs
+++ b/tests/Resend.Tests/ResendClientTests.OAuthGrants.cs
@@ -11,9 +11,9 @@ public partial class ResendClientTests
 
         Assert.NotNull( resp );
         Assert.NotNull( resp.Content );
-        Assert.NotEmpty( resp.Content );
+        Assert.NotEmpty( resp.Content.Data );
 
-        var grant = resp.Content[ 0 ];
+        var grant = resp.Content.Data[ 0 ];
 
         Assert.NotEqual( Guid.Empty, grant.Id );
         Assert.Equal( "Resend CLI", grant.Client.Name );
@@ -31,6 +31,7 @@ public partial class ResendClientTests
 
         Assert.NotNull( resp );
         Assert.NotNull( resp.Content );
+        Assert.Equal( "oauth_grant", resp.Content.Object );
         Assert.Equal( id, resp.Content.Id );
         Assert.Equal( "revoked_from_api", resp.Content.RevokedReason );
     }

--- a/tools/Resend.ApiServer/Controllers/OAuthGrantController.cs
+++ b/tools/Resend.ApiServer/Controllers/OAuthGrantController.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.Mvc;
+using Resend.Payloads;
+
+namespace Resend.ApiServer.Controllers;
+
+/// <summary />
+[ApiController]
+public class OAuthGrantController : ControllerBase
+{
+    private readonly ILogger<OAuthGrantController> _logger;
+
+
+    /// <summary />
+    public OAuthGrantController( ILogger<OAuthGrantController> logger )
+    {
+        _logger = logger;
+    }
+
+
+    /// <summary />
+    [HttpGet]
+    [Route( "oauth/grants" )]
+    public ListOf<OAuthGrant> OAuthGrantList()
+    {
+        _logger.LogDebug( "OAuthGrantList" );
+
+        var list = new List<OAuthGrant>();
+        list.Add( new OAuthGrant()
+        {
+            Id = Guid.NewGuid(),
+            ClientId = Guid.NewGuid(),
+            Scopes = new List<string>() { "emails:send" },
+            MomentCreated = DateTime.UtcNow,
+            Client = new OAuthGrantClient() { Name = "Resend CLI" },
+        } );
+
+        return new ListOf<OAuthGrant>() { Data = list };
+    }
+
+
+    /// <summary />
+    [HttpDelete]
+    [Route( "oauth/grants/{id}" )]
+    public OAuthGrantRevoked OAuthGrantRevoke( [FromRoute] Guid id )
+    {
+        _logger.LogDebug( "OAuthGrantRevoke" );
+
+        return new OAuthGrantRevoked()
+        {
+            Id = id,
+            MomentRevoked = DateTime.UtcNow,
+            RevokedReason = "revoked_from_api",
+        };
+    }
+}

--- a/tools/Resend.ApiServer/Controllers/OAuthGrantController.cs
+++ b/tools/Resend.ApiServer/Controllers/OAuthGrantController.cs
@@ -20,7 +20,7 @@ public class OAuthGrantController : ControllerBase
     /// <summary />
     [HttpGet]
     [Route( "oauth/grants" )]
-    public ListOf<OAuthGrant> OAuthGrantList()
+    public PaginatedResult<OAuthGrant> OAuthGrantList()
     {
         _logger.LogDebug( "OAuthGrantList" );
 
@@ -34,7 +34,7 @@ public class OAuthGrantController : ControllerBase
             Client = new OAuthGrantClient() { Name = "Resend CLI" },
         } );
 
-        return new ListOf<OAuthGrant>() { Data = list };
+        return new PaginatedResult<OAuthGrant>() { HasMore = false, Data = list };
     }
 
 
@@ -47,6 +47,7 @@ public class OAuthGrantController : ControllerBase
 
         return new OAuthGrantRevoked()
         {
+            Object = "oauth_grant",
             Id = id,
             MomentRevoked = DateTime.UtcNow,
             RevokedReason = "revoked_from_api",

--- a/tools/Resend.Cli/OAuthGrant/OAuthGrantListCommand.cs
+++ b/tools/Resend.Cli/OAuthGrant/OAuthGrantListCommand.cs
@@ -27,7 +27,7 @@ public class OAuthGrantListCommand
     public async Task<int> OnExecuteAsync()
     {
         var res = await _resend.OAuthGrantListAsync();
-        var grants = res.Content;
+        var grants = res.Content.Data;
 
 
         if ( this.InJson == true )
@@ -50,8 +50,8 @@ public class OAuthGrantListCommand
             {
                 table.AddRow(
                     new Markup( g.Id.ToString() ),
-                    new Markup( g.Client.Name ),
-                    new Markup( string.Join( ", ", g.Scopes ) ),
+                    new Markup( Markup.Escape( g.Client.Name ) ),
+                    new Markup( Markup.Escape( string.Join( ", ", g.Scopes ) ) ),
                     new Markup( g.MomentCreated.ToString() )
                     );
             }

--- a/tools/Resend.Cli/OAuthGrant/OAuthGrantListCommand.cs
+++ b/tools/Resend.Cli/OAuthGrant/OAuthGrantListCommand.cs
@@ -1,0 +1,64 @@
+using McMaster.Extensions.CommandLineUtils;
+using Spectre.Console;
+using System.Text.Json;
+
+namespace Resend.Cli.OAuthGrant;
+
+/// <summary />
+[Command( "list", Description = "Lists OAuth grants" )]
+public class OAuthGrantListCommand
+{
+    private readonly IResend _resend;
+
+
+    /// <summary />
+    [Option( "-j|--json", CommandOptionType.NoValue, Description = "Emit output as JSON array" )]
+    public bool InJson { get; set; }
+
+
+    /// <summary />
+    public OAuthGrantListCommand( IResend resend )
+    {
+        _resend = resend;
+    }
+
+
+    /// <summary />
+    public async Task<int> OnExecuteAsync()
+    {
+        var res = await _resend.OAuthGrantListAsync();
+        var grants = res.Content;
+
+
+        if ( this.InJson == true )
+        {
+            var jso = new JsonSerializerOptions() { WriteIndented = true };
+            var json = JsonSerializer.Serialize( grants, jso );
+
+            Console.WriteLine( json );
+        }
+        else
+        {
+            var table = new Table();
+            table.Border = TableBorder.SimpleHeavy;
+            table.AddColumn( "Grant Id" );
+            table.AddColumn( "Client" );
+            table.AddColumn( "Scopes" );
+            table.AddColumn( "Created" );
+
+            foreach ( var g in grants )
+            {
+                table.AddRow(
+                    new Markup( g.Id.ToString() ),
+                    new Markup( g.Client.Name ),
+                    new Markup( string.Join( ", ", g.Scopes ) ),
+                    new Markup( g.MomentCreated.ToString() )
+                    );
+            }
+
+            AnsiConsole.Write( table );
+        }
+
+        return 0;
+    }
+}

--- a/tools/Resend.Cli/OAuthGrant/OAuthGrantRevokeCommand.cs
+++ b/tools/Resend.Cli/OAuthGrant/OAuthGrantRevokeCommand.cs
@@ -1,0 +1,33 @@
+using McMaster.Extensions.CommandLineUtils;
+using System.ComponentModel.DataAnnotations;
+
+namespace Resend.Cli.OAuthGrant;
+
+/// <summary />
+[Command( "revoke", Description = "Revoke an OAuth grant" )]
+public class OAuthGrantRevokeCommand
+{
+    private readonly IResend _resend;
+
+
+    /// <summary />
+    [Argument( 0, Description = "OAuth grant identifier" )]
+    [Required]
+    public Guid? GrantId { get; set; }
+
+
+    /// <summary />
+    public OAuthGrantRevokeCommand( IResend resend )
+    {
+        _resend = resend;
+    }
+
+
+    /// <summary />
+    public async Task<int> OnExecuteAsync()
+    {
+        await _resend.OAuthGrantRevokeAsync( this.GrantId!.Value );
+
+        return 0;
+    }
+}

--- a/tools/Resend.Cli/OAuthGrantCommand.cs
+++ b/tools/Resend.Cli/OAuthGrantCommand.cs
@@ -1,0 +1,17 @@
+using McMaster.Extensions.CommandLineUtils;
+
+namespace Resend.Cli;
+
+/// <summary />
+[Command( "oauth-grant", Description = "OAuth grant management" )]
+[Subcommand( typeof( OAuthGrant.OAuthGrantListCommand ) )]
+[Subcommand( typeof( OAuthGrant.OAuthGrantRevokeCommand ) )]
+public class OAuthGrantCommand
+{
+    /// <summary />
+    public int OnExecute( CommandLineApplication app )
+    {
+        app.ShowHelp();
+        return 1;
+    }
+}

--- a/tools/Resend.Cli/Program.cs
+++ b/tools/Resend.Cli/Program.cs
@@ -12,6 +12,7 @@ namespace Resend.Cli;
 [Subcommand( typeof( ContactPropCommand ) )]
 [Subcommand( typeof( DomainCommand ) )]
 [Subcommand( typeof( EmailCommand ) )]
+[Subcommand( typeof( OAuthGrantCommand ) )]
 [Subcommand( typeof( ReceiveCommand ) )]
 [Subcommand( typeof( SegmentCommand ) )]
 [Subcommand( typeof( TemplateCommand ) )]


### PR DESCRIPTION
Implements the two new OAuth endpoints announced for the API:

- `GET /oauth/grants` → `IResend.OAuthGrantListAsync`
- `DELETE /oauth/grants/:oauthGrantId` → `IResend.OAuthGrantRevokeAsync`

Field shapes were verified against **resend-openapi#70**, **resend-node#998**, and the docs (list-grants / revoke-grant).

## What's included
- **Models** (`src/Resend/OAuthGrant.cs`): `OAuthGrant` (`id`, `client_id`, `scopes`, `resource`, `created_at`, `revoked_at`, `revoked_reason`, nested `client`), `OAuthGrantClient` (`name`, `logo_uri`), and `OAuthGrantRevoked` for the revoke response.
- **Interface + client**: new `#region OAuth Grants` in `IResend`; implementation in a new `ResendClient.OAuthGrants.cs` partial, reusing the existing `ListOf<T>` wrapper and `Execute` helpers.
- **CLI**: `resend oauth-grant list` (with `-j|--json`) and `resend oauth-grant revoke <id>`.
- **Tests**: list + revoke against the fake `ApiServer` (new `OAuthGrantController`). Full suite passes on .NET 8.

## Design notes / decisions for review
- **Revoke returns a body.** Unlike the SDK's other `*DeleteAsync` methods (which return `ResendResponse`), this endpoint returns `{ object, id, revoked_at, revoked_reason }`, so `OAuthGrantRevokeAsync` returns `ResendResponse<OAuthGrantRevoked>` (matching resend-node). Named *Revoke* rather than *Delete* to match the documented operation. Happy to switch to a void `...DeleteAsync` if you'd rather match the delete convention.
- **Dates as `DateTime`.** The docs show `created_at` in a Postgres-style format (`2026-04-08 00:11:13.110779+00`) while revoke uses ISO; I verified both parse correctly through the existing `JsonUtcDateTimeConverter`, so I kept the idiomatic `DateTime`/`DateTime?` typing rather than opaque strings.
- **Pagination not surfaced.** `GET /oauth/grants` supports `limit`/`after`/`before` and returns `has_more`, but the SDK's list convention (`ListOf<T>`) drops the wrapper and existing list methods (api-keys, domains) take no paging params. Kept consistent; surfacing pagination would be a broader SDK change across all list endpoints.
- **`oauthGrantId` typed `Guid`** to match the SDK's id convention (ids are UUIDs in practice), though the OpenAPI path param is an unconstrained string.

Note: resend-openapi#70 and resend-node#998 are still open, so shapes could shift before GA.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add OAuth grants support to the SDK and CLI: list grants with pagination and revoke a grant. This lets users see connected clients and invalidate their tokens when needed.

- New Features
  - API: `OAuthGrantListAsync(PaginatedQuery?)` → `ResendResponse<PaginatedResult<OAuthGrant>>`; `OAuthGrantRevokeAsync(Guid)` → `ResendResponse<OAuthGrantRevoked>`.
  - Models: `OAuthGrant`, `OAuthGrantClient`, `OAuthGrantRevoked` (includes `object` discriminator).
  - Client: implementation in `ResendClient.OAuthGrants.cs`; interface updates in `IResend`.
  - CLI: `resend oauth-grant list` (supports `--json`) and `resend oauth-grant revoke <id>`.
  - Tests: list + revoke tests and a fake `ApiServer` controller.

- Notes
  - List now supports pagination (`limit`, `before`, `after`) and returns `has_more`.
  - Revoke returns a body; method returns `ResendResponse<OAuthGrantRevoked>` and is named “Revoke”.
  - IDs are `Guid`; date fields use the existing UTC `DateTime` converter.
  - CLI output escapes Spectre markup for API-provided fields.

<sup>Written for commit 0396a9e4c96f02e46ce188bc88a8ad7436b06fdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

