### PR TITLE
Post-merge hardening: CLI verbose null-guard (#117) + out-of-order webhook test (#118)

### DIFF
--- a/tests/Resend.Webhooks.Tests/WebhookOutOfOrderTests.cs
+++ b/tests/Resend.Webhooks.Tests/WebhookOutOfOrderTests.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+
+namespace Resend.Webhooks.Tests;
+
+/// <summary />
+public class WebhookOutOfOrderTests
+{
+    /// <summary />
+    /// <remarks>
+    /// Real Resend payloads serialize <c>type</c> last (after <c>created_at</c>
+    /// and <c>data</c>); the converter must not assume <c>type</c> comes first.
+    /// </remarks>
+    [Fact]
+    public void EmailEventTypeLastDeserializes()
+    {
+        var json = """
+        {
+          "created_at": "2026-07-09T18:23:37.867Z",
+          "data": {
+            "created_at": "2026-07-09T18:23:37.236Z",
+            "email_id": "c4bd0130-17f1-4e49-90bc-856308df9bb5",
+            "failed": { "reason": "domain_not_verified" },
+            "from": "Acme <onboarding@resend.dev>",
+            "subject": "Test",
+            "template_id": "2dc48b66-eef5-4601-b509-ca33f3e10b60",
+            "to": [ "to@example.com" ]
+          },
+          "type": "email.failed"
+        }
+        """;
+
+        var evt = JsonSerializer.Deserialize<WebhookEvent>( json );
+
+        Assert.NotNull( evt );
+        Assert.Equal( WebhookEventType.EmailFailed, evt.EventType );
+
+        var data = evt.DataAs<EmailEventData>();
+        Assert.Equal( "domain_not_verified", data.Failed?.Reason );
+        Assert.Equal( "2dc48b66-eef5-4601-b509-ca33f3e10b60", data.TemplateId );
+    }
+
+
+    /// <summary />
+    /// <remarks>Contact events serialize <c>created_at</c> before <c>type</c>.</remarks>
+    [Fact]
+    public void ContactEventCreatedAtFirstDeserializes()
+    {
+        var json = """
+        {
+          "created_at": "2026-07-09T18:23:37.867Z",
+          "type": "contact.created",
+          "data": {
+            "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+            "created_at": "2026-07-09T18:23:37.236Z",
+            "updated_at": "2026-07-09T18:23:37.236Z",
+            "email": "to@example.com",
+            "unsubscribed": false
+          }
+        }
+        """;
+
+        var evt = JsonSerializer.Deserialize<WebhookEvent>( json );
+
+        Assert.NotNull( evt );
+        Assert.Equal( WebhookEventType.ContactCreated, evt.EventType );
+        Assert.Equal( "to@example.com", evt.DataAs<ContactEventData>().Email );
+    }
+
+
+    /// <summary />
+    [Theory]
+    [InlineData( """{ "type": "email.sent", "type": "email.sent", "created_at": "2026-07-09T18:23:37.867Z", "data": {} }""" )]
+    [InlineData( """{ "type": "email.sent", "created_at": "2026-07-09T18:23:37.867Z" }""" )]
+    [InlineData( """{ "type": "email.sent", "created_at": "2026-07-09T18:23:37.867Z", "data": {}, "extra": 1 }""" )]
+    public void MalformedEnvelopeThrows( string json )
+    {
+        Assert.ThrowsAny<JsonException>( () => JsonSerializer.Deserialize<WebhookEvent>( json ) );
+    }
+}

--- a/tools/Resend.Cli/Email/EmailSendCommand.cs
+++ b/tools/Resend.Cli/Email/EmailSendCommand.cs
@@ -122,7 +122,9 @@ public class EmailSendCommand
          */
         if ( this.Verbose == true )
         {
-            Console.WriteLine( "From: {0}", message.From.Email );
+            if ( message.From != null )
+                Console.WriteLine( "From: {0}", message.From.Email );
+
             Console.WriteLine( "  To: {0}", string.Join( ", ", message.To ) );
             Console.WriteLine( "Subj: {0}", message.Subject );
 


### PR DESCRIPTION
Two small hardening follow-ups found during release QA.

## CLI `--verbose` null-guard (regression from #117)
#117 made `EmailMessage.From`/`Subject` nullable so hosted-template sends can omit them. But `EmailSendCommand`'s `--verbose` branch did `message.From.Email` unconditionally → **NullReferenceException** when `from` is omitted (exactly the template-send case #117 enables). Guarded it. Verified: `email send --verbose` with `from` omitted now prints output and completes instead of crashing.

## Out-of-order webhook regression test (guards #118)
#118 made `WebhookEventConverter` parse `type`/`created_at`/`data` in any order, but the repo had **no test** for it — existing tests round-trip through the SDK's own writer, which always emits `type` first, so they'd pass even on the pre-#118 converter. Added `WebhookOutOfOrderTests`:
- **email event with `type` last** (the real Resend/staging ordering, confirmed live during QA)
- **contact event with `created_at` first**
- malformed envelopes (duplicate `type`, missing `data`, unknown property) → `JsonException`

## Verification
Build + Resend.Webhooks.Tests on .NET 8: **11/11 pass**; CLI builds and the verbose path was exercised with `from` omitted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the CLI and webhook handling after recent changes. Prevents a verbose-mode crash on template sends and adds tests to ensure out-of-order webhook envelopes are parsed correctly.

- **Bug Fixes**
  - CLI: Prevent NRE in `email send --verbose` when `from` is omitted (template sends).
  - Webhooks: Add regression tests for out-of-order envelopes (email `type` last, contact `created_at` first) and ensure malformed payloads throw `JsonException`.

<sup>Written for commit dfe7a5cd7b9f8dd0919c1b3d314a64dad48de37e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

