### PR TITLE
Auto-generate release notes in release.sh

### DIFF
--- a/cicd/release.sh
+++ b/cicd/release.sh
@@ -79,7 +79,7 @@ dotnet nuget push "nupkg/*.nupkg" --api-key ${NUGET_APIKEY} --source=https://api
 # Release, including artifacts
 # ------------------------------------------------------------------------
 
-gh release create v${VERSION} --notes="Release v${VERSION}" \
+gh release create v${VERSION} --generate-notes --title "v${VERSION}" \
    artifacts/resend-cli-win-x64-${VERSION}.zip \
    artifacts/resend-cli-linux-x64-${VERSION}.zip \
    artifacts/resend-cli-osx-x64-${VERSION}.zip


### PR DESCRIPTION
Automated releases hardcoded `--notes="Release v${VERSION}"`, so they shipped with no changelog (e.g. **v0.5.1** has no "What's Changed", unlike the manually-published v0.5.0).

Switch the release step to:
```
gh release create v${VERSION} --generate-notes --title "v${VERSION}" …
```
`--generate-notes` makes GitHub build the **What's Changed + Full Changelog** section from merged PRs automatically, on every future release. CLI binary assets are unchanged.

Should be merged before tagging the next release so that release picks it up (the workflow runs `release.sh` from the tagged commit).

Verified `bash -n cicd/release.sh` parses.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `gh release create --generate-notes` in `cicd/release.sh` and set `--title "v${VERSION}"` so releases auto-include What's Changed and Full Changelog from merged PRs. Fixes missing changelogs in automated releases; CLI assets unchanged; merge before next tag.

<sup>Written for commit 081573f76a81879b355690b7a36e6f37a45683a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

