### PR TITLE
Bump fallback Version to 0.6.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <Version>0.1.0</Version>
+    <Version>0.6.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
`Directory.Build.props` still declared `<Version>0.1.0</Version>`, which had drifted far behind the actual release line (now v0.6.0).

This value is only a **fallback for local builds** — `release.sh` overrides it with `-p:Version=${VERSION}` derived from the git tag, so released packages have always been versioned correctly regardless. But a local `dotnet build`/`pack` (or anyone reading the repo) would see a misleading `0.1.0`.

Bump it to `0.6.0` to match the current release. No effect on the tag-driven release flow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update fallback version in `Directory.Build.props` from 0.1.0 to 0.6.0 so local `dotnet build`/`pack` match the current release line. No change to the tag-driven release flow; `release.sh` still sets the version from git tags.

<sup>Written for commit 476ca8345cc09d15f3ca6028c0cebd5ecc550282. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

