### PR TITLE
Document and test batch support for tags

### DIFF
--- a/src/Resend/EmailMessage.cs
+++ b/src/Resend/EmailMessage.cs
@@ -82,6 +82,9 @@ public class EmailMessage
     /// <summary>
     /// Filename and content of attachments (max 40mb per email).
     /// </summary>
+    /// <remarks>
+    /// Not supported when sending batch emails via <see cref="IResend.EmailBatchAsync" />.
+    /// </remarks>
     [JsonPropertyName( "attachments" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
     public List<EmailAttachment>? Attachments { get; set; }
@@ -89,6 +92,9 @@ public class EmailMessage
     /// <summary>
     /// Email tags.
     /// </summary>
+    /// <remarks>
+    /// Supported for both single and batch email sends.
+    /// </remarks>
     [JsonPropertyName( "tags" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
     public List<EmailTag>? Tags { get; set; }
@@ -107,6 +113,9 @@ public class EmailMessage
     /// <summary>
     /// Moment for which the email is scheduled for/at.
     /// </summary>
+    /// <remarks>
+    /// Not supported when sending batch emails via <see cref="IResend.EmailBatchAsync" />.
+    /// </remarks>
     [JsonPropertyName( "scheduled_at" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
     public DateTimeOrHuman? MomentSchedule { get; set; }

--- a/src/Resend/EmailMessage.cs
+++ b/src/Resend/EmailMessage.cs
@@ -82,9 +82,6 @@ public class EmailMessage
     /// <summary>
     /// Filename and content of attachments (max 40mb per email).
     /// </summary>
-    /// <remarks>
-    /// Not supported when sending batch emails via <see cref="IResend.EmailBatchAsync" />.
-    /// </remarks>
     [JsonPropertyName( "attachments" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
     public List<EmailAttachment>? Attachments { get; set; }

--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -74,8 +74,9 @@ public interface IResend
     /// Send a batch of emails, if and only if all messages are valid.
     /// </summary>
     /// <remarks>
-    /// Each <see cref="EmailMessage" /> supports <see cref="EmailMessage.Tags" />,
-    /// <see cref="EmailMessage.Attachments" />, and <see cref="EmailMessage.MomentSchedule" />.
+    /// Each <see cref="EmailMessage" /> supports <see cref="EmailMessage.Tags" />.
+    /// <see cref="EmailMessage.Attachments" /> and <see cref="EmailMessage.MomentSchedule" />
+    /// are not supported on batch sends.
     /// </remarks>
     /// <param name="emails">
     /// List of emails.
@@ -95,8 +96,9 @@ public interface IResend
     /// valid.
     /// </summary>
     /// <remarks>
-    /// Each <see cref="EmailMessage" /> supports <see cref="EmailMessage.Tags" />,
-    /// <see cref="EmailMessage.Attachments" />, and <see cref="EmailMessage.MomentSchedule" />.
+    /// Each <see cref="EmailMessage" /> supports <see cref="EmailMessage.Tags" />.
+    /// <see cref="EmailMessage.Attachments" /> and <see cref="EmailMessage.MomentSchedule" />
+    /// are not supported on batch sends.
     /// </remarks>
     /// <param name="idempotencyKey">
     /// Idempotency key.
@@ -117,8 +119,9 @@ public interface IResend
     /// Send a batch of emails.
     /// </summary>
     /// <remarks>
-    /// Each <see cref="EmailMessage" /> supports <see cref="EmailMessage.Tags" />,
-    /// <see cref="EmailMessage.Attachments" />, and <see cref="EmailMessage.MomentSchedule" />.
+    /// Each <see cref="EmailMessage" /> supports <see cref="EmailMessage.Tags" />.
+    /// <see cref="EmailMessage.Attachments" /> and <see cref="EmailMessage.MomentSchedule" />
+    /// are not supported on batch sends.
     /// </remarks>
     /// <param name="emails">
     /// List of emails.
@@ -139,8 +142,9 @@ public interface IResend
     /// Send a batch of emails.
     /// </summary>
     /// <remarks>
-    /// Each <see cref="EmailMessage" /> supports <see cref="EmailMessage.Tags" />,
-    /// <see cref="EmailMessage.Attachments" />, and <see cref="EmailMessage.MomentSchedule" />.
+    /// Each <see cref="EmailMessage" /> supports <see cref="EmailMessage.Tags" />.
+    /// <see cref="EmailMessage.Attachments" /> and <see cref="EmailMessage.MomentSchedule" />
+    /// are not supported on batch sends.
     /// </remarks>
     /// <param name="idempotencyKey">
     /// Idempotency key.

--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -75,8 +75,7 @@ public interface IResend
     /// </summary>
     /// <remarks>
     /// Each <see cref="EmailMessage" /> supports <see cref="EmailMessage.Tags" />.
-    /// <see cref="EmailMessage.Attachments" /> and <see cref="EmailMessage.MomentSchedule" />
-    /// are not supported on batch sends.
+    /// <see cref="EmailMessage.MomentSchedule" /> is not supported on batch sends.
     /// </remarks>
     /// <param name="emails">
     /// List of emails.
@@ -97,8 +96,7 @@ public interface IResend
     /// </summary>
     /// <remarks>
     /// Each <see cref="EmailMessage" /> supports <see cref="EmailMessage.Tags" />.
-    /// <see cref="EmailMessage.Attachments" /> and <see cref="EmailMessage.MomentSchedule" />
-    /// are not supported on batch sends.
+    /// <see cref="EmailMessage.MomentSchedule" /> is not supported on batch sends.
     /// </remarks>
     /// <param name="idempotencyKey">
     /// Idempotency key.
@@ -120,8 +118,7 @@ public interface IResend
     /// </summary>
     /// <remarks>
     /// Each <see cref="EmailMessage" /> supports <see cref="EmailMessage.Tags" />.
-    /// <see cref="EmailMessage.Attachments" /> and <see cref="EmailMessage.MomentSchedule" />
-    /// are not supported on batch sends.
+    /// <see cref="EmailMessage.MomentSchedule" /> is not supported on batch sends.
     /// </remarks>
     /// <param name="emails">
     /// List of emails.
@@ -143,8 +140,7 @@ public interface IResend
     /// </summary>
     /// <remarks>
     /// Each <see cref="EmailMessage" /> supports <see cref="EmailMessage.Tags" />.
-    /// <see cref="EmailMessage.Attachments" /> and <see cref="EmailMessage.MomentSchedule" />
-    /// are not supported on batch sends.
+    /// <see cref="EmailMessage.MomentSchedule" /> is not supported on batch sends.
     /// </remarks>
     /// <param name="idempotencyKey">
     /// Idempotency key.

--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -73,6 +73,10 @@ public interface IResend
     /// <summary>
     /// Send a batch of emails, if and only if all messages are valid.
     /// </summary>
+    /// <remarks>
+    /// Each <see cref="EmailMessage" /> supports <see cref="EmailMessage.Tags" />,
+    /// <see cref="EmailMessage.Attachments" />, and <see cref="EmailMessage.MomentSchedule" />.
+    /// </remarks>
     /// <param name="emails">
     /// List of emails.
     /// </param>
@@ -90,6 +94,10 @@ public interface IResend
     /// duplicate submissions. Emails are only send if and only if all messages are
     /// valid.
     /// </summary>
+    /// <remarks>
+    /// Each <see cref="EmailMessage" /> supports <see cref="EmailMessage.Tags" />,
+    /// <see cref="EmailMessage.Attachments" />, and <see cref="EmailMessage.MomentSchedule" />.
+    /// </remarks>
     /// <param name="idempotencyKey">
     /// Idempotency key.
     /// </param>
@@ -108,6 +116,10 @@ public interface IResend
     /// <summary>
     /// Send a batch of emails.
     /// </summary>
+    /// <remarks>
+    /// Each <see cref="EmailMessage" /> supports <see cref="EmailMessage.Tags" />,
+    /// <see cref="EmailMessage.Attachments" />, and <see cref="EmailMessage.MomentSchedule" />.
+    /// </remarks>
     /// <param name="emails">
     /// List of emails.
     /// </param>
@@ -126,6 +138,10 @@ public interface IResend
     /// <summary>
     /// Send a batch of emails.
     /// </summary>
+    /// <remarks>
+    /// Each <see cref="EmailMessage" /> supports <see cref="EmailMessage.Tags" />,
+    /// <see cref="EmailMessage.Attachments" />, and <see cref="EmailMessage.MomentSchedule" />.
+    /// </remarks>
     /// <param name="idempotencyKey">
     /// Idempotency key.
     /// </param>

--- a/tests/Resend.Tests/EmailMessageTests.cs
+++ b/tests/Resend.Tests/EmailMessageTests.cs
@@ -37,4 +37,77 @@ public class EmailMessageTests
         Assert.Contains( "\"subject\":\"Hello\"", json );
         Assert.Contains( "\"from\"", json );
     }
+
+
+    /// <summary />
+    [Fact]
+    public void SerializesBatchFields()
+    {
+        var message = new EmailMessage()
+        {
+            From = "from@example.com",
+            To = "to@example.com",
+            Subject = "Hello",
+            HtmlBody = "<p>Hi</p>",
+            Tags = [ new EmailTag { Name = "category", Value = "confirm_email" } ],
+            MomentSchedule = "in 1 hour",
+            Attachments = [
+                new EmailAttachment()
+                {
+                    Filename = "file.txt",
+                    Content = "hello"u8.ToArray(),
+                },
+            ],
+        };
+
+        var json = JsonSerializer.Serialize( message );
+
+        Assert.Contains( "\"tags\":[{\"name\":\"category\",\"value\":\"confirm_email\"}]", json );
+        Assert.Contains( "\"scheduled_at\":\"in 1 hour\"", json );
+        Assert.Contains( "\"attachments\":[{\"filename\":\"file.txt\",\"content\":\"aGVsbG8=\"}]", json );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public void DeserializesBatchFields()
+    {
+        const string json = """
+            {
+              "from": "from@example.com",
+              "to": ["to@example.com"],
+              "subject": "Hello",
+              "html": "<p>Hi</p>",
+              "tags": [
+                {
+                  "name": "category",
+                  "value": "confirm_email"
+                }
+              ],
+              "scheduled_at": "in 1 hour",
+              "attachments": [
+                {
+                  "filename": "file.txt",
+                  "content": "aGVsbG8="
+                }
+              ]
+            }
+            """;
+
+        var message = JsonSerializer.Deserialize<EmailMessage>( json );
+
+        Assert.NotNull( message );
+        Assert.NotNull( message.Tags );
+        Assert.Single( message.Tags );
+        Assert.Equal( "category", message.Tags[ 0 ].Name );
+        Assert.Equal( "confirm_email", message.Tags[ 0 ].Value );
+        Assert.NotNull( message.MomentSchedule );
+        Assert.False( message.MomentSchedule.Value.IsMoment );
+        Assert.Equal( "in 1 hour", message.MomentSchedule.Value.Human );
+        Assert.NotNull( message.Attachments );
+        Assert.Single( message.Attachments );
+        Assert.Equal( "file.txt", message.Attachments[ 0 ].Filename );
+        Assert.True( message.Attachments[ 0 ].Content?.IsByteArray );
+        Assert.Equal( "hello"u8.ToArray(), message.Attachments[ 0 ].Content?.ByteArray );
+    }
 }

--- a/tests/Resend.Tests/EmailMessageTests.cs
+++ b/tests/Resend.Tests/EmailMessageTests.cs
@@ -41,7 +41,7 @@ public class EmailMessageTests
 
     /// <summary />
     [Fact]
-    public void SerializesBatchFields()
+    public void SerializesTags()
     {
         var message = new EmailMessage()
         {
@@ -50,27 +50,17 @@ public class EmailMessageTests
             Subject = "Hello",
             HtmlBody = "<p>Hi</p>",
             Tags = [ new EmailTag { Name = "category", Value = "confirm_email" } ],
-            MomentSchedule = "in 1 hour",
-            Attachments = [
-                new EmailAttachment()
-                {
-                    Filename = "file.txt",
-                    Content = "hello"u8.ToArray(),
-                },
-            ],
         };
 
         var json = JsonSerializer.Serialize( message );
 
         Assert.Contains( "\"tags\":[{\"name\":\"category\",\"value\":\"confirm_email\"}]", json );
-        Assert.Contains( "\"scheduled_at\":\"in 1 hour\"", json );
-        Assert.Contains( "\"attachments\":[{\"filename\":\"file.txt\",\"content\":\"aGVsbG8=\"}]", json );
     }
 
 
     /// <summary />
     [Fact]
-    public void DeserializesBatchFields()
+    public void DeserializesTags()
     {
         const string json = """
             {
@@ -83,13 +73,6 @@ public class EmailMessageTests
                   "name": "category",
                   "value": "confirm_email"
                 }
-              ],
-              "scheduled_at": "in 1 hour",
-              "attachments": [
-                {
-                  "filename": "file.txt",
-                  "content": "aGVsbG8="
-                }
               ]
             }
             """;
@@ -101,13 +84,5 @@ public class EmailMessageTests
         Assert.Single( message.Tags );
         Assert.Equal( "category", message.Tags[ 0 ].Name );
         Assert.Equal( "confirm_email", message.Tags[ 0 ].Value );
-        Assert.NotNull( message.MomentSchedule );
-        Assert.False( message.MomentSchedule.Value.IsMoment );
-        Assert.Equal( "in 1 hour", message.MomentSchedule.Value.Human );
-        Assert.NotNull( message.Attachments );
-        Assert.Single( message.Attachments );
-        Assert.Equal( "file.txt", message.Attachments[ 0 ].Filename );
-        Assert.True( message.Attachments[ 0 ].Content?.IsByteArray );
-        Assert.Equal( "hello"u8.ToArray(), message.Attachments[ 0 ].Content?.ByteArray );
     }
 }

--- a/tests/Resend.Tests/ResendClientTests.cs
+++ b/tests/Resend.Tests/ResendClientTests.cs
@@ -91,14 +91,6 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
             To = "to@example.com",
             HtmlBody = "From unit test!",
             Tags = [ new EmailTag { Name = "category", Value = "confirm_email" } ],
-            MomentSchedule = DateTime.UtcNow.AddHours( 1 ),
-            Attachments = [
-                new EmailAttachment()
-                {
-                    Filename = "note.txt",
-                    Content = "batch attachment"u8.ToArray(),
-                },
-            ],
         };
 
         var list = new List<EmailMessage>() { email, email };

--- a/tests/Resend.Tests/ResendClientTests.cs
+++ b/tests/Resend.Tests/ResendClientTests.cs
@@ -84,11 +84,22 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
     [Fact]
     public async Task EmailBatch()
     {
-        var email = new EmailMessage();
-        email.Subject = "Unit testing";
-        email.From = "from@example.com";
-        email.To = "to@example.com";
-        email.HtmlBody = "From unit test!";
+        var email = new EmailMessage()
+        {
+            Subject = "Unit testing",
+            From = "from@example.com",
+            To = "to@example.com",
+            HtmlBody = "From unit test!",
+            Tags = [ new EmailTag { Name = "category", Value = "confirm_email" } ],
+            MomentSchedule = DateTime.UtcNow.AddHours( 1 ),
+            Attachments = [
+                new EmailAttachment()
+                {
+                    Filename = "note.txt",
+                    Content = "batch attachment"u8.ToArray(),
+                },
+            ],
+        };
 
         var list = new List<EmailMessage>() { email, email };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The batch send API supports `tags` per email. `scheduled_at` is not supported on batch sends.

`EmailMessage` is shared between single and batch sends and already models tags for both. This change documents batch tag support and adds tag-specific coverage:

- Serialization/deserialization tests for `tags` on `EmailMessage`
- Integration test update for `EmailBatchAsync` using tags
- `IResend` batch method remarks documenting tag support
- `EmailMessage` remark noting that `MomentSchedule` is not supported on batch sends

## Test plan

- [x] `dotnet test tests/Resend.Tests/Resend.Tests.csproj --filter "FullyQualifiedName~EmailMessageTests|FullyQualifiedName~EmailBatch"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d340ba9a-45ff-46b2-8b62-f364900ddf59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d340ba9a-45ff-46b2-8b62-f364900ddf59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document batch send support for per-email `tags` in the .NET SDK and clarify that `scheduled_at` is not supported for batch sends. Add `tags` JSON (de)serialization tests, update the `EmailBatchAsync` integration test to include `tags`, and add remarks in `EmailMessage` and `IResend` batch methods.

<sup>Written for commit 8c9d0f24aea8cc8a44ed71191ffd7ae6c918e894. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

