### PR TITLE
Add Domain Claims API support (claim + get + verify)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Resend/DomainClaim.cs
+++ b/src/Resend/DomainClaim.cs
@@ -1,0 +1,88 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// A claim on a domain that is already verified by another team.
+/// </summary>
+/// <see href="https://resend.com/docs/dashboard/domains/claim" />
+public class DomainClaim
+{
+    /// <summary>
+    /// Object type discriminator.
+    /// </summary>
+    [JsonPropertyName( "object" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? Object { get; set; }
+
+    /// <summary>
+    /// Claim identifier.
+    /// </summary>
+    [JsonPropertyName( "id" )]
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Domain name being claimed.
+    /// </summary>
+    [JsonPropertyName( "name" )]
+    public string Name { get; set; } = default!;
+
+    /// <summary>
+    /// Status of the claim.
+    /// </summary>
+    [JsonPropertyName( "status" )]
+    public DomainClaimStatus Status { get; set; }
+
+    /// <summary>
+    /// Identifier of the placeholder domain created for this claim.
+    /// </summary>
+    [JsonPropertyName( "domain_id" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public Guid? DomainId { get; set; }
+
+    /// <summary>
+    /// Region from which the emails for this domain are delivered.
+    /// </summary>
+    [JsonPropertyName( "region" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public DeliveryRegion? Region { get; set; }
+
+    /// <summary>
+    /// TXT record that must be added to DNS to verify the claim.
+    /// </summary>
+    [JsonPropertyName( "record" )]
+    public DomainClaimRecord Record { get; set; } = default!;
+
+    /// <summary>
+    /// Reason the claim is blocked, if it is blocked by an ownership-safety check.
+    /// </summary>
+    /// <remarks>
+    /// Free-text on the API; observed values include <c>grace_period</c> and
+    /// <c>recent_owner_activity</c>. Not modelled as an enum so that unknown values
+    /// do not break deserialization.
+    /// </remarks>
+    [JsonPropertyName( "blocked_reason" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? BlockedReason { get; set; }
+
+    /// <summary>
+    /// Reason the claim failed, if it has failed.
+    /// </summary>
+    [JsonPropertyName( "failure_reason" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? FailureReason { get; set; }
+
+    /// <summary>
+    /// Moment when the claim was created.
+    /// </summary>
+    [JsonPropertyName( "created_at" )]
+    [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
+    public DateTime MomentCreated { get; set; }
+
+    /// <summary>
+    /// Moment when the claim expires.
+    /// </summary>
+    [JsonPropertyName( "expires_at" )]
+    [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
+    public DateTime MomentExpires { get; set; }
+}

--- a/src/Resend/DomainClaimData.cs
+++ b/src/Resend/DomainClaimData.cs
@@ -1,0 +1,53 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// Request object to claim a domain that is already verified by another team.
+/// </summary>
+public class DomainClaimData
+{
+    /// <summary>
+    /// Name of the domain to claim.
+    /// </summary>
+    [JsonPropertyName( "name" )]
+    public string DomainName { get; set; } = default!;
+
+    /// <summary>
+    /// Delivery region.
+    /// </summary>
+    [JsonPropertyName( "region" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public DeliveryRegion? Region { get; set; }
+
+    /// <summary>
+    /// Overrides the default value of `Return-Path`.
+    /// </summary>
+    /// <remarks>
+    /// By default, Resend will use the `send` subdomain for the `Return-Path` address.
+    /// </remarks>
+    [JsonPropertyName( "custom_return_path" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? CustomReturnPath { get; set; }
+
+    /// <summary>
+    /// Track the open rate of each email.
+    /// </summary>
+    [JsonPropertyName( "open_tracking" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public bool? OpenTracking { get; set; }
+
+    /// <summary>
+    /// Track clicks within the body of each HTML email.
+    /// </summary>
+    [JsonPropertyName( "click_tracking" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public bool? ClickTracking { get; set; }
+
+    /// <summary>
+    /// Subdomain for click and open tracking (for example, <c>links</c> for <c>links.example.com</c>).
+    /// </summary>
+    [JsonPropertyName( "tracking_subdomain" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? TrackingSubdomain { get; set; }
+}

--- a/src/Resend/DomainClaimRecord.cs
+++ b/src/Resend/DomainClaimRecord.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// TXT record that must be added to DNS to verify a domain claim.
+/// </summary>
+public class DomainClaimRecord
+{
+    /// <summary>
+    /// Type of DNS record to be added.
+    /// </summary>
+    /// <remarks>
+    /// Example value: TXT.
+    /// </remarks>
+    [JsonPropertyName( "type" )]
+    public string RecordType { get; set; } = default!;
+
+    /// <summary>
+    /// Name of the DNS record required for verification.
+    /// </summary>
+    [JsonPropertyName( "name" )]
+    public string Name { get; set; } = default!;
+
+    /// <summary>
+    /// Value of the DNS record required for verification.
+    /// </summary>
+    [JsonPropertyName( "value" )]
+    public string Value { get; set; } = default!;
+
+    /// <summary>
+    /// Time to Live, in seconds -- or Auto.
+    /// </summary>
+    [JsonPropertyName( "ttl" )]
+    public string TimeToLive { get; set; } = default!;
+}

--- a/src/Resend/DomainClaimStatus.cs
+++ b/src/Resend/DomainClaimStatus.cs
@@ -1,0 +1,59 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// Status of a domain claim.
+/// </summary>
+/// <see href="https://resend.com/docs/dashboard/domains/claim" />
+[JsonConverter( typeof( JsonStringEnumValueConverter<DomainClaimStatus> ) )]
+public enum DomainClaimStatus
+{
+    /// <summary>
+    /// Claim has been created and is awaiting DNS verification.
+    /// </summary>
+    [JsonStringValue( "pending" )]
+    Pending,
+
+    /// <summary>
+    /// Claim's TXT record has been verified.
+    /// </summary>
+    [JsonStringValue( "verified" )]
+    Verified,
+
+    /// <summary>
+    /// Claim has completed and the domain has been transferred.
+    /// </summary>
+    [JsonStringValue( "completed" )]
+    Completed,
+
+    /// <summary>
+    /// Claim is temporarily blocked by an ownership-safety check.
+    /// </summary>
+    [JsonStringValue( "blocked" )]
+    Blocked,
+
+    /// <summary>
+    /// Claim has expired before being verified.
+    /// </summary>
+    [JsonStringValue( "expired" )]
+    Expired,
+
+    /// <summary>
+    /// Claim has been superseded by a newer claim for the same domain.
+    /// </summary>
+    [JsonStringValue( "superseded" )]
+    Superseded,
+
+    /// <summary>
+    /// Claim has been canceled.
+    /// </summary>
+    [JsonStringValue( "canceled" )]
+    Canceled,
+
+    /// <summary>
+    /// Claim has failed.
+    /// </summary>
+    [JsonStringValue( "failed" )]
+    Failed,
+}

--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -300,6 +300,79 @@ public interface IResend
     /// <see href="https://resend.com/docs/api-reference/domains/delete-domain"/>
     Task<ResendResponse> DomainDeleteAsync( Guid domainId, CancellationToken cancellationToken = default );
 
+    /// <summary>
+    /// Claim a domain that is already verified by another team.
+    /// </summary>
+    /// <param name="domainName">
+    /// Name of the domain to claim.
+    /// </param>
+    /// <param name="region">
+    /// Delivery region.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Cancellation token.
+    /// </param>
+    /// <returns>
+    /// Domain claim.
+    /// </returns>
+    /// <remarks>
+    /// Use this when creating a domain fails because the domain is already verified by
+    /// another team. Resend creates a placeholder domain on your team and returns a claim
+    /// with a TXT record to add to your DNS.
+    /// </remarks>
+    /// <see href="https://resend.com/docs/api-reference/domains/claim-domain"/>
+    Task<ResendResponse<DomainClaim>> DomainClaimAsync( string domainName, DeliveryRegion? region = null, CancellationToken cancellationToken = default );
+
+    /// <summary>
+    /// Claim a domain that is already verified by another team.
+    /// </summary>
+    /// <param name="data">
+    /// Claim information.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Cancellation token.
+    /// </param>
+    /// <returns>
+    /// Domain claim.
+    /// </returns>
+    /// <see href="https://resend.com/docs/api-reference/domains/claim-domain"/>
+    Task<ResendResponse<DomainClaim>> DomainClaimAsync( DomainClaimData data, CancellationToken cancellationToken = default );
+
+    /// <summary>
+    /// Retrieve the latest claim for a domain.
+    /// </summary>
+    /// <param name="domainId">
+    /// Placeholder domain identifier returned when the claim was created.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Cancellation token.
+    /// </param>
+    /// <returns>
+    /// Domain claim.
+    /// </returns>
+    /// <see href="https://resend.com/docs/api-reference/domains/get-domain-claim"/>
+    Task<ResendResponse<DomainClaim>> DomainClaimRetrieveAsync( Guid domainId, CancellationToken cancellationToken = default );
+
+    /// <summary>
+    /// Trigger DNS verification for a domain claim.
+    /// </summary>
+    /// <param name="domainId">
+    /// Placeholder domain identifier returned when the claim was created.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Cancellation token.
+    /// </param>
+    /// <returns>
+    /// Domain claim.
+    /// </returns>
+    /// <remarks>
+    /// Starts an asynchronous verification process. Add the TXT record returned by
+    /// <see cref="DomainClaimAsync(DomainClaimData, CancellationToken)"/> before calling this,
+    /// then poll <see cref="DomainClaimRetrieveAsync(Guid, CancellationToken)"/> to follow the status.
+    /// </remarks>
+    /// <see href="https://resend.com/docs/api-reference/domains/verify-domain-claim"/>
+    Task<ResendResponse<DomainClaim>> DomainClaimVerifyAsync( Guid domainId, CancellationToken cancellationToken = default );
+
     #endregion
 
     #region Api Keys

--- a/src/Resend/ResendClient.DomainClaims.cs
+++ b/src/Resend/ResendClient.DomainClaims.cs
@@ -1,0 +1,51 @@
+using System.Net.Http.Json;
+
+namespace Resend;
+
+public partial class ResendClient
+{
+    /// <inheritdoc />
+    public Task<ResendResponse<DomainClaim>> DomainClaimAsync( string domainName, DeliveryRegion? region = null, CancellationToken cancellationToken = default )
+    {
+        var path = $"/domains/claim";
+        var req = new HttpRequestMessage( HttpMethod.Post, path );
+        req.Content = JsonContent.Create( new DomainClaimData()
+        {
+            DomainName = domainName,
+            Region = region,
+        } );
+
+        return Execute<DomainClaim, DomainClaim>( req, ( x ) => x, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
+    public Task<ResendResponse<DomainClaim>> DomainClaimAsync( DomainClaimData data, CancellationToken cancellationToken = default )
+    {
+        var path = $"/domains/claim";
+        var req = new HttpRequestMessage( HttpMethod.Post, path );
+        req.Content = JsonContent.Create( data );
+
+        return Execute<DomainClaim, DomainClaim>( req, ( x ) => x, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
+    public Task<ResendResponse<DomainClaim>> DomainClaimRetrieveAsync( Guid domainId, CancellationToken cancellationToken = default )
+    {
+        var path = $"/domains/{domainId}/claim";
+        var req = new HttpRequestMessage( HttpMethod.Get, path );
+
+        return Execute<DomainClaim, DomainClaim>( req, ( x ) => x, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
+    public Task<ResendResponse<DomainClaim>> DomainClaimVerifyAsync( Guid domainId, CancellationToken cancellationToken = default )
+    {
+        var path = $"/domains/{domainId}/claim/verify";
+        var req = new HttpRequestMessage( HttpMethod.Post, path );
+
+        return Execute<DomainClaim, DomainClaim>( req, ( x ) => x, cancellationToken );
+    }
+}

--- a/tests/Resend.Tests/DomainClaimTests.cs
+++ b/tests/Resend.Tests/DomainClaimTests.cs
@@ -1,0 +1,188 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace Resend.Tests;
+
+/// <summary />
+public class DomainClaimTests
+{
+    /// <summary />
+    [Fact]
+    public void DomainClaimData_serializes_name_and_region()
+    {
+        var data = new DomainClaimData()
+        {
+            DomainName = "example.com",
+            Region = DeliveryRegion.UsEast1,
+        };
+
+        var json = JsonSerializer.Serialize( data );
+        Assert.Contains( "\"name\":\"example.com\"", json );
+        Assert.Contains( "\"region\":\"us-east-1\"", json );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task JsonContent_Create_omits_null_optionals()
+    {
+        var data = new DomainClaimData()
+        {
+            DomainName = "example.com",
+        };
+
+        using var content = JsonContent.Create( data );
+        var json = await content.ReadAsStringAsync();
+
+        Assert.DoesNotContain( "region", json );
+        Assert.DoesNotContain( "custom_return_path", json );
+        Assert.DoesNotContain( "open_tracking", json );
+        Assert.DoesNotContain( "tracking_subdomain", json );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public void DomainClaim_deserializes_documented_payload()
+    {
+        const string json = """
+            {
+              "object": "domain_claim",
+              "id": "dacf4072-4119-4d88-932f-6c6126d3a9d1",
+              "name": "example.com",
+              "status": "pending",
+              "domain_id": "d91cd9bd-1176-453e-8fc1-35364d380206",
+              "region": "us-east-1",
+              "record": {
+                "type": "TXT",
+                "name": "example.com",
+                "value": "resend-domain-verification=3f8a1c2d4e5b6a7f8091a2b3c4d5e6f7",
+                "ttl": "Auto"
+              },
+              "blocked_reason": null,
+              "failure_reason": null,
+              "created_at": "2026-06-16 17:12:02.059593+00",
+              "expires_at": "2026-06-23 17:12:02.059593+00"
+            }
+            """;
+
+        var claim = JsonSerializer.Deserialize<DomainClaim>( json );
+
+        Assert.NotNull( claim );
+        Assert.Equal( "domain_claim", claim!.Object );
+        Assert.Equal( Guid.Parse( "dacf4072-4119-4d88-932f-6c6126d3a9d1" ), claim.Id );
+        Assert.Equal( "example.com", claim.Name );
+        Assert.Equal( DomainClaimStatus.Pending, claim.Status );
+        Assert.Equal( Guid.Parse( "d91cd9bd-1176-453e-8fc1-35364d380206" ), claim.DomainId );
+        Assert.Equal( DeliveryRegion.UsEast1, claim.Region );
+        Assert.Null( claim.BlockedReason );
+        Assert.Null( claim.FailureReason );
+
+        Assert.NotNull( claim.Record );
+        Assert.Equal( "TXT", claim.Record.RecordType );
+        Assert.Equal( "example.com", claim.Record.Name );
+        Assert.Equal( "Auto", claim.Record.TimeToLive );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public void DomainClaim_deserializes_blocked_reason()
+    {
+        const string json = """
+            {
+              "object": "domain_claim",
+              "id": "dacf4072-4119-4d88-932f-6c6126d3a9d1",
+              "name": "example.com",
+              "status": "blocked",
+              "domain_id": "d91cd9bd-1176-453e-8fc1-35364d380206",
+              "region": "us-east-1",
+              "record": {
+                "type": "TXT",
+                "name": "example.com",
+                "value": "resend-domain-verification=abc",
+                "ttl": "Auto"
+              },
+              "blocked_reason": "recent_owner_activity",
+              "failure_reason": null,
+              "created_at": "2026-06-16T17:12:02.059593+00:00",
+              "expires_at": "2026-06-23T17:12:02.059593+00:00"
+            }
+            """;
+
+        var claim = JsonSerializer.Deserialize<DomainClaim>( json );
+
+        Assert.NotNull( claim );
+        Assert.Equal( DomainClaimStatus.Blocked, claim!.Status );
+        Assert.Equal( "recent_owner_activity", claim.BlockedReason );
+    }
+
+
+    /// <summary>
+    /// blocked_reason is free-text on the API, so an unknown value must not break deserialization.
+    /// </summary>
+    [Fact]
+    public void DomainClaim_deserializes_unknown_blocked_reason()
+    {
+        const string json = """
+            {
+              "object": "domain_claim",
+              "id": "dacf4072-4119-4d88-932f-6c6126d3a9d1",
+              "name": "example.com",
+              "status": "blocked",
+              "domain_id": "d91cd9bd-1176-453e-8fc1-35364d380206",
+              "region": "us-east-1",
+              "record": {
+                "type": "TXT",
+                "name": "example.com",
+                "value": "resend-domain-verification=abc",
+                "ttl": "Auto"
+              },
+              "blocked_reason": "some_future_reason",
+              "failure_reason": null,
+              "created_at": "2026-06-16 17:12:02.059593+00",
+              "expires_at": "2026-06-23 17:12:02.059593+00"
+            }
+            """;
+
+        var claim = JsonSerializer.Deserialize<DomainClaim>( json );
+
+        Assert.NotNull( claim );
+        Assert.Equal( "some_future_reason", claim!.BlockedReason );
+    }
+
+
+    /// <summary>
+    /// Real payloads do not guarantee property order; deserialization must not depend on it.
+    /// </summary>
+    [Fact]
+    public void DomainClaim_deserializes_out_of_order()
+    {
+        const string json = """
+            {
+              "expires_at": "2026-06-23T17:12:02.059593+00:00",
+              "created_at": "2026-06-16T17:12:02.059593+00:00",
+              "record": {
+                "ttl": "Auto",
+                "value": "resend-domain-verification=abc",
+                "name": "example.com",
+                "type": "TXT"
+              },
+              "region": "eu-west-1",
+              "status": "verified",
+              "name": "example.com",
+              "domain_id": "d91cd9bd-1176-453e-8fc1-35364d380206",
+              "id": "dacf4072-4119-4d88-932f-6c6126d3a9d1",
+              "object": "domain_claim"
+            }
+            """;
+
+        var claim = JsonSerializer.Deserialize<DomainClaim>( json );
+
+        Assert.NotNull( claim );
+        Assert.Equal( DomainClaimStatus.Verified, claim!.Status );
+        Assert.Equal( DeliveryRegion.EuWest1, claim.Region );
+        Assert.Equal( "example.com", claim.Name );
+        Assert.Equal( "TXT", claim.Record.RecordType );
+    }
+}

--- a/tests/Resend.Tests/ResendClientTests.DomainClaims.cs
+++ b/tests/Resend.Tests/ResendClientTests.DomainClaims.cs
@@ -1,0 +1,71 @@
+namespace Resend.Tests;
+
+/// <summary />
+public partial class ResendClientTests
+{
+    /// <summary />
+    [Fact]
+    public async Task DomainClaim()
+    {
+        var resp = await _resend.DomainClaimAsync( "example.com" );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( "domain_claim", resp.Content.Object );
+        Assert.Equal( "example.com", resp.Content.Name );
+        Assert.Equal( DomainClaimStatus.Pending, resp.Content.Status );
+        Assert.NotNull( resp.Content.DomainId );
+        Assert.Equal( "TXT", resp.Content.Record.RecordType );
+        Assert.Equal( "Auto", resp.Content.Record.TimeToLive );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task DomainClaimWithData()
+    {
+        var resp = await _resend.DomainClaimAsync( new DomainClaimData()
+        {
+            DomainName = "example.com",
+            Region = DeliveryRegion.EuWest1,
+        } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( "example.com", resp.Content.Name );
+        Assert.Equal( DeliveryRegion.EuWest1, resp.Content.Region );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task DomainClaimRetrieve()
+    {
+        var domainId = Guid.NewGuid();
+
+        var resp = await _resend.DomainClaimRetrieveAsync( domainId );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( domainId, resp.Content.DomainId );
+        Assert.Equal( DomainClaimStatus.Pending, resp.Content.Status );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task DomainClaimVerify()
+    {
+        var domainId = Guid.NewGuid();
+
+        var resp = await _resend.DomainClaimVerifyAsync( domainId );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( domainId, resp.Content.DomainId );
+    }
+}

--- a/tools/Resend.ApiServer/Controllers/DomainController.cs
+++ b/tools/Resend.ApiServer/Controllers/DomainController.cs
@@ -148,4 +148,88 @@ public class DomainController : ControllerBase
 
         return Ok();
     }
+
+
+    /// <summary />
+    [HttpPost]
+    [Route( "domains/claim" )]
+    public DomainClaim DomainClaim( [FromBody] DomainClaimData request )
+    {
+        _logger.LogDebug( "DomainClaim" );
+
+        return new DomainClaim()
+        {
+            Object = "domain_claim",
+            Id = Guid.NewGuid(),
+            Name = request.DomainName,
+            Status = DomainClaimStatus.Pending,
+            DomainId = Guid.NewGuid(),
+            Region = request.Region ?? DeliveryRegion.UsEast1,
+            Record = new DomainClaimRecord()
+            {
+                RecordType = "TXT",
+                Name = request.DomainName,
+                Value = "resend-domain-verification=3f8a1c2d4e5b6a7f8091a2b3c4d5e6f7",
+                TimeToLive = "Auto",
+            },
+            MomentCreated = DateTime.UtcNow,
+            MomentExpires = DateTime.UtcNow.AddDays( 7 ),
+        };
+    }
+
+
+    /// <summary />
+    [HttpGet]
+    [Route( "domains/{id}/claim" )]
+    public DomainClaim DomainClaimRetrieve( [FromRoute] Guid id )
+    {
+        _logger.LogDebug( "DomainClaimRetrieve" );
+
+        return new DomainClaim()
+        {
+            Object = "domain_claim",
+            Id = Guid.NewGuid(),
+            Name = "example.com",
+            Status = DomainClaimStatus.Pending,
+            DomainId = id,
+            Region = DeliveryRegion.UsEast1,
+            Record = new DomainClaimRecord()
+            {
+                RecordType = "TXT",
+                Name = "example.com",
+                Value = "resend-domain-verification=3f8a1c2d4e5b6a7f8091a2b3c4d5e6f7",
+                TimeToLive = "Auto",
+            },
+            MomentCreated = DateTime.UtcNow,
+            MomentExpires = DateTime.UtcNow.AddDays( 7 ),
+        };
+    }
+
+
+    /// <summary />
+    [HttpPost]
+    [Route( "domains/{id}/claim/verify" )]
+    public DomainClaim DomainClaimVerify( [FromRoute] Guid id )
+    {
+        _logger.LogDebug( "DomainClaimVerify" );
+
+        return new DomainClaim()
+        {
+            Object = "domain_claim",
+            Id = Guid.NewGuid(),
+            Name = "example.com",
+            Status = DomainClaimStatus.Pending,
+            DomainId = id,
+            Region = DeliveryRegion.UsEast1,
+            Record = new DomainClaimRecord()
+            {
+                RecordType = "TXT",
+                Name = "example.com",
+                Value = "resend-domain-verification=3f8a1c2d4e5b6a7f8091a2b3c4d5e6f7",
+                TimeToLive = "Auto",
+            },
+            MomentCreated = DateTime.UtcNow,
+            MomentExpires = DateTime.UtcNow.AddDays( 7 ),
+        };
+    }
 }

--- a/tools/Resend.Cli/Domain/Claim/DomainClaimCreateCommand.cs
+++ b/tools/Resend.Cli/Domain/Claim/DomainClaimCreateCommand.cs
@@ -1,0 +1,60 @@
+﻿using McMaster.Extensions.CommandLineUtils;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+
+namespace Resend.Cli.Domain.Claim;
+
+/// <summary />
+[Command( "create", Description = "Claim a domain that is already verified by another team" )]
+public class DomainClaimCreateCommand
+{
+    private readonly IResend _resend;
+
+
+    /// <summary />
+    [Option( "-n|--name", CommandOptionType.SingleValue, Description = "Domain name" )]
+    [Required]
+    public string DomainName { get; set; } = default!;
+
+    /// <summary />
+    [Option( "-r|--region", CommandOptionType.SingleValue, Description = "Delivery region" )]
+    public DeliveryRegion? Region { get; set; }
+
+    /// <summary />
+    [Option( "--return-path", CommandOptionType.SingleValue, Description = "Return path" )]
+    public string? ReturnPath { get; set; }
+
+
+    /// <summary />
+    public DomainClaimCreateCommand( IResend resend )
+    {
+        _resend = resend;
+    }
+
+
+    /// <summary />
+    public async Task<int> OnExecuteAsync()
+    {
+        var res = await _resend.DomainClaimAsync( new DomainClaimData()
+        {
+            DomainName = this.DomainName,
+            Region = this.Region,
+            CustomReturnPath = this.ReturnPath,
+        } );
+        var claim = res.Content;
+
+
+        /*
+         *
+         */
+        var jso = new JsonSerializerOptions()
+        {
+            WriteIndented = true,
+        };
+
+        var json = JsonSerializer.Serialize( claim, jso );
+        Console.WriteLine( json );
+
+        return 0;
+    }
+}

--- a/tools/Resend.Cli/Domain/Claim/DomainClaimCreateCommand.cs
+++ b/tools/Resend.Cli/Domain/Claim/DomainClaimCreateCommand.cs
@@ -1,6 +1,5 @@
 ﻿using McMaster.Extensions.CommandLineUtils;
 using System.ComponentModel.DataAnnotations;
-using System.Text.Json;
 
 namespace Resend.Cli.Domain.Claim;
 
@@ -24,6 +23,10 @@ public class DomainClaimCreateCommand
     [Option( "--return-path", CommandOptionType.SingleValue, Description = "Return path" )]
     public string? ReturnPath { get; set; }
 
+    /// <summary />
+    [Option( "-j|--json", CommandOptionType.NoValue, Description = "Emit output as JSON" )]
+    public bool InJson { get; set; }
+
 
     /// <summary />
     public DomainClaimCreateCommand( IResend resend )
@@ -41,19 +44,7 @@ public class DomainClaimCreateCommand
             Region = this.Region,
             CustomReturnPath = this.ReturnPath,
         } );
-        var claim = res.Content;
-
-
-        /*
-         *
-         */
-        var jso = new JsonSerializerOptions()
-        {
-            WriteIndented = true,
-        };
-
-        var json = JsonSerializer.Serialize( claim, jso );
-        Console.WriteLine( json );
+        DomainClaimRender.Write( res.Content, this.InJson );
 
         return 0;
     }

--- a/tools/Resend.Cli/Domain/Claim/DomainClaimGetCommand.cs
+++ b/tools/Resend.Cli/Domain/Claim/DomainClaimGetCommand.cs
@@ -1,0 +1,41 @@
+﻿using McMaster.Extensions.CommandLineUtils;
+using Spectre.Console;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+
+namespace Resend.Cli.Domain.Claim;
+
+/// <summary />
+[Command( "get", Description = "Retrieve the latest claim for a domain" )]
+public class DomainClaimGetCommand
+{
+    private readonly IResend _resend;
+
+
+    /// <summary />
+    [Argument( 0, Description = "Placeholder domain identifier" )]
+    [Required]
+    public Guid? DomainId { get; set; }
+
+    /// <summary />
+    [Option( "-j|--json", CommandOptionType.NoValue, Description = "Emit output as JSON" )]
+    public bool InJson { get; set; }
+
+
+    /// <summary />
+    public DomainClaimGetCommand( IResend resend )
+    {
+        _resend = resend;
+    }
+
+
+    /// <summary />
+    public async Task<int> OnExecuteAsync()
+    {
+        var res = await _resend.DomainClaimRetrieveAsync( this.DomainId!.Value );
+
+        DomainClaimRender.Write( res.Content, this.InJson );
+
+        return 0;
+    }
+}

--- a/tools/Resend.Cli/Domain/Claim/DomainClaimRender.cs
+++ b/tools/Resend.Cli/Domain/Claim/DomainClaimRender.cs
@@ -1,0 +1,57 @@
+﻿using Spectre.Console;
+using System.Text.Json;
+
+namespace Resend.Cli.Domain.Claim;
+
+/// <summary />
+public static class DomainClaimRender
+{
+    /// <summary />
+    public static void Write( DomainClaim claim, bool inJson )
+    {
+        if ( inJson == true )
+        {
+            var jso = new JsonSerializerOptions() { WriteIndented = true };
+            var json = JsonSerializer.Serialize( claim, jso );
+
+            Console.WriteLine( json );
+            return;
+        }
+
+
+        var head = new Table();
+        head.Border = TableBorder.SimpleHeavy;
+        head.AddColumn( "Claim Id" );
+        head.AddColumn( "Domain Id" );
+        head.AddColumn( "Name" );
+        head.AddColumn( "Region" );
+        head.AddColumn( "Status" );
+
+        head.AddRow(
+            new Markup( claim.Id.ToString() ),
+            new Markup( claim.DomainId?.ToString() ?? "" ),
+            new Markup( claim.Name ),
+            new Markup( claim.Region?.ToString() ?? "" ),
+            new Markup( claim.Status.ToString() )
+            );
+
+        AnsiConsole.Write( head );
+
+
+        var table = new Table();
+        table.Border = TableBorder.SimpleHeavy;
+        table.AddColumn( "Type" );
+        table.AddColumn( "Name" );
+        table.AddColumn( "TTL" );
+        table.AddColumn( "Value" );
+
+        table.AddRow(
+            new Markup( claim.Record.RecordType ),
+            new Markup( claim.Record.Name ),
+            new Markup( claim.Record.TimeToLive ),
+            new Markup( claim.Record.Value )
+            );
+
+        AnsiConsole.Write( table );
+    }
+}

--- a/tools/Resend.Cli/Domain/Claim/DomainClaimRender.cs
+++ b/tools/Resend.Cli/Domain/Claim/DomainClaimRender.cs
@@ -38,20 +38,23 @@ public static class DomainClaimRender
         AnsiConsole.Write( head );
 
 
-        var table = new Table();
-        table.Border = TableBorder.SimpleHeavy;
-        table.AddColumn( "Type" );
-        table.AddColumn( "Name" );
-        table.AddColumn( "TTL" );
-        table.AddColumn( "Value" );
+        if ( claim.Record != null )
+        {
+            var table = new Table();
+            table.Border = TableBorder.SimpleHeavy;
+            table.AddColumn( "Type" );
+            table.AddColumn( "Name" );
+            table.AddColumn( "TTL" );
+            table.AddColumn( "Value" );
 
-        table.AddRow(
-            new Markup( claim.Record.RecordType ),
-            new Markup( claim.Record.Name ),
-            new Markup( claim.Record.TimeToLive ),
-            new Markup( claim.Record.Value )
-            );
+            table.AddRow(
+                new Markup( claim.Record.RecordType ),
+                new Markup( claim.Record.Name ),
+                new Markup( claim.Record.TimeToLive ),
+                new Markup( claim.Record.Value )
+                );
 
-        AnsiConsole.Write( table );
+            AnsiConsole.Write( table );
+        }
     }
 }

--- a/tools/Resend.Cli/Domain/Claim/DomainClaimVerifyCommand.cs
+++ b/tools/Resend.Cli/Domain/Claim/DomainClaimVerifyCommand.cs
@@ -1,0 +1,39 @@
+﻿using McMaster.Extensions.CommandLineUtils;
+using System.ComponentModel.DataAnnotations;
+
+namespace Resend.Cli.Domain.Claim;
+
+/// <summary />
+[Command( "verify", Description = "Trigger DNS verification for a domain claim" )]
+public class DomainClaimVerifyCommand
+{
+    private readonly IResend _resend;
+
+
+    /// <summary />
+    [Argument( 0, Description = "Placeholder domain identifier" )]
+    [Required]
+    public Guid? DomainId { get; set; }
+
+    /// <summary />
+    [Option( "-j|--json", CommandOptionType.NoValue, Description = "Emit output as JSON" )]
+    public bool InJson { get; set; }
+
+
+    /// <summary />
+    public DomainClaimVerifyCommand( IResend resend )
+    {
+        _resend = resend;
+    }
+
+
+    /// <summary />
+    public async Task<int> OnExecuteAsync()
+    {
+        var res = await _resend.DomainClaimVerifyAsync( this.DomainId!.Value );
+
+        DomainClaimRender.Write( res.Content, this.InJson );
+
+        return 0;
+    }
+}

--- a/tools/Resend.Cli/Domain/DomainClaimCommand.cs
+++ b/tools/Resend.Cli/Domain/DomainClaimCommand.cs
@@ -1,0 +1,18 @@
+﻿using McMaster.Extensions.CommandLineUtils;
+
+namespace Resend.Cli.Domain;
+
+/// <summary />
+[Command( "claim", Description = "Claim a domain that is already verified by another team" )]
+[Subcommand( typeof( Claim.DomainClaimCreateCommand ) )]
+[Subcommand( typeof( Claim.DomainClaimGetCommand ) )]
+[Subcommand( typeof( Claim.DomainClaimVerifyCommand ) )]
+public class DomainClaimCommand
+{
+    /// <summary />
+    public int OnExecute( CommandLineApplication app )
+    {
+        app.ShowHelp();
+        return 1;
+    }
+}

--- a/tools/Resend.Cli/DomainCommand.cs
+++ b/tools/Resend.Cli/DomainCommand.cs
@@ -5,6 +5,7 @@ namespace Resend.Cli;
 /// <summary />
 [Command( "domain", Description = "Email (sender) domain management" )]
 [Subcommand( typeof( Domain.DomainAddCommand ))]
+[Subcommand( typeof( Domain.DomainClaimCommand ) )]
 [Subcommand( typeof( Domain.DomainDeleteCommand ))]
 [Subcommand( typeof( Domain.DomainListCommand ) )]
 [Subcommand( typeof( Domain.DomainRetrieveCommand ) )]


### PR DESCRIPTION
## Summary

Adds SDK support for the newly-released **Domain Claims API**, mirroring the Node.js SDK:

- `POST /domains/claim` → `DomainClaimAsync(name, region?)` and `DomainClaimAsync(DomainClaimData)`
- `GET /domains/{id}/claim` → `DomainClaimRetrieveAsync(domainId)`
- `POST /domains/{id}/claim/verify` → `DomainClaimVerifyAsync(domainId)`

### What's included
- **Models**: `DomainClaim`, `DomainClaimRecord`, `DomainClaimData`, and the `DomainClaimStatus` enum (`pending`/`verified`/`completed`/`blocked`/`expired`/`superseded`/`canceled`/`failed`).
- **Client**: `ResendClient.DomainClaims.cs` (partial class, matching the OAuth-grants convention) + three methods on `IResend`, documented in the existing `Domains` region.
- **CLI**: a `domain claim create|get|verify` subcommand group.
- **Fake API server**: three routes so integration tests exercise the wire path.
- **Tests**: 5 serialization unit tests (documented payload, `+00` space-separated datetimes, a `blocked_reason` value, an **out-of-order / type-last** payload, and an **unknown `blocked_reason`**) + 4 integration tests against the in-memory server.

### Design note: `blocked_reason`
Modelled as a nullable **`string`**, not an enum. The Node SDK uses a string-union, but the API column is free-text on the server, so a `JsonStringEnumValueConverter` would throw on any unrecognized value and break deserialization of the whole response. A regression test covers an unknown value.

## Verification
- **Monorepo (public-api)**: request/response schemas, nullability of `domain_id`/`region`, the 8-value status `pgEnum`, and the free-text `blocked_reason` column all cross-checked against `origin/main` server source.
- **Live staging API**: all three endpoints exercised via raw `curl` and end-to-end through the SDK (CLI); every field mapped, `+00` datetimes parsed, test placeholder domain cleaned up.
- **Tests**: 131/131 pass on .NET 8 (matching CI); build clean, 0 warnings. No target-framework change (still `net8.0`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Domain Claims API support to the SDK and CLI. Create a claim, check its status, and trigger verification for domains already verified by another team; also bumps fallback version to 0.7.0.

- **New Features**
  - SDK: `DomainClaimAsync(name, region?)`, `DomainClaimAsync(DomainClaimData)`, `DomainClaimRetrieveAsync(domainId)`, `DomainClaimVerifyAsync(domainId)`.
  - Models: `DomainClaim`, `DomainClaimRecord`, `DomainClaimData`, and `DomainClaimStatus` (pending, verified, completed, blocked, expired, superseded, canceled, failed). `blocked_reason` is a nullable string to tolerate unknown server values.
  - CLI: `domain claim create`, `domain claim get`, `domain claim verify`.
  - Tests: serialization edge cases and integration tests using in-memory API routes.

- **Bug Fixes**
  - CLI renderer now guards null `record` when printing claims.
  - `domain claim create` reuses the shared renderer for consistent output.

<sup>Written for commit 39ac5f54bc318a1ec3bc552f7b7a78529c2c048c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

