### PR TITLE
Add Suppressions API support (add + list + get + remove + batch)

### DIFF
--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -1123,6 +1123,9 @@ public interface IResend
     /// <param name="suppressionIdOrEmail">Suppression identifier or the suppressed email address.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Suppression.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="suppressionIdOrEmail"/> is null, empty or whitespace.
+    /// </exception>
     /// <see href="https://resend.com/docs/api-reference/suppressions/get-suppression"/>
     Task<ResendResponse<Suppression>> SuppressionRetrieveAsync( string suppressionIdOrEmail, CancellationToken cancellationToken = default );
 
@@ -1132,6 +1135,9 @@ public interface IResend
     /// <param name="suppressionIdOrEmail">Suppression identifier or the suppressed email address.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Outcome of the removal.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="suppressionIdOrEmail"/> is null, empty or whitespace.
+    /// </exception>
     /// <see href="https://resend.com/docs/api-reference/suppressions/remove-suppression"/>
     Task<ResendResponse<SuppressionRemoveResult>> SuppressionRemoveAsync( string suppressionIdOrEmail, CancellationToken cancellationToken = default );
 

--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -1093,6 +1093,106 @@ public interface IResend
 
     #endregion
 
+    #region Suppressions
+
+    /// <summary>
+    /// Adds an email address to the suppression list.
+    /// </summary>
+    /// <param name="email">Email address to suppress.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>New suppression identifier.</returns>
+    /// <see href="https://resend.com/docs/api-reference/suppressions/add-suppression"/>
+    Task<ResendResponse<Guid>> SuppressionAddAsync( string email, CancellationToken cancellationToken = default );
+
+    /// <summary>
+    /// Lists suppressions.
+    /// </summary>
+    /// <param name="query">Pagination query, optionally filtered by origin.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Page of suppressions.</returns>
+    /// <remarks>
+    /// List entries do not carry the <c>object</c> discriminator; use
+    /// <see cref="SuppressionRetrieveAsync"/> for the full <see cref="Suppression"/>.
+    /// </remarks>
+    /// <see href="https://resend.com/docs/api-reference/suppressions/list-suppressions"/>
+    Task<ResendResponse<PaginatedResult<SuppressionSummary>>> SuppressionListAsync( SuppressionListQuery? query = null, CancellationToken cancellationToken = default );
+
+    /// <summary>
+    /// Retrieves a single suppression.
+    /// </summary>
+    /// <param name="suppressionIdOrEmail">Suppression identifier or the suppressed email address.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Suppression.</returns>
+    /// <see href="https://resend.com/docs/api-reference/suppressions/get-suppression"/>
+    Task<ResendResponse<Suppression>> SuppressionRetrieveAsync( string suppressionIdOrEmail, CancellationToken cancellationToken = default );
+
+    /// <summary>
+    /// Removes a single suppression, allowing Resend to deliver to the address again.
+    /// </summary>
+    /// <param name="suppressionIdOrEmail">Suppression identifier or the suppressed email address.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Outcome of the removal.</returns>
+    /// <see href="https://resend.com/docs/api-reference/suppressions/remove-suppression"/>
+    Task<ResendResponse<SuppressionRemoveResult>> SuppressionRemoveAsync( string suppressionIdOrEmail, CancellationToken cancellationToken = default );
+
+    /// <summary>
+    /// Adds up to 100 email addresses to the suppression list at once.
+    /// </summary>
+    /// <param name="emails">Email addresses to suppress.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>New suppression identifiers.</returns>
+    /// <remarks>
+    /// Fewer identifiers may be returned than addresses sent: the API lowercases, trims and
+    /// dedupes the addresses, so case variants of one address collapse into a single entry.
+    /// Do not pair the result with the input by index. Re-adding an already-suppressed
+    /// address is not an error -- it returns the existing identifier.
+    /// </remarks>
+    /// <see href="https://resend.com/docs/api-reference/suppressions/add-suppressions"/>
+    Task<ResendResponse<List<Guid>>> SuppressionBatchAddAsync( IEnumerable<string> emails, CancellationToken cancellationToken = default );
+
+    /// <summary>
+    /// Removes up to 100 suppressions at once, by email address.
+    /// </summary>
+    /// <param name="emails">Suppressed email addresses to remove.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Outcome of each removal.</returns>
+    /// <remarks>
+    /// The API accepts either email addresses or identifiers in a single call, never both;
+    /// use <see cref="SuppressionBatchRemoveAsync(IEnumerable{Guid}, CancellationToken)"/> to
+    /// remove by identifier.
+    /// <para>
+    /// Only addresses that were actually suppressed appear in the result, and the addresses
+    /// are lowercased, trimmed and deduped first -- so the result may be shorter than the
+    /// input and must not be paired with it by index. Unlike
+    /// <see cref="SuppressionRemoveAsync"/>, an address that was not suppressed is silently
+    /// absent rather than a not-found error.
+    /// </para>
+    /// </remarks>
+    /// <see href="https://resend.com/docs/api-reference/suppressions/remove-suppressions"/>
+    Task<ResendResponse<List<SuppressionRemoveResult>>> SuppressionBatchRemoveAsync( IEnumerable<string> emails, CancellationToken cancellationToken = default );
+
+    /// <summary>
+    /// Removes up to 100 suppressions at once, by identifier.
+    /// </summary>
+    /// <param name="suppressionIds">Suppression identifiers to remove.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Outcome of each removal.</returns>
+    /// <remarks>
+    /// The API accepts either email addresses or identifiers in a single call, never both;
+    /// use <see cref="SuppressionBatchRemoveAsync(IEnumerable{string}, CancellationToken)"/> to
+    /// remove by email address.
+    /// <para>
+    /// Only identifiers that were actually suppressed appear in the result, so it may be
+    /// shorter than the input and must not be paired with it by index. Unlike
+    /// <see cref="SuppressionRemoveAsync"/>, an identifier that was not suppressed is
+    /// silently absent rather than a not-found error.
+    /// </para>
+    /// </remarks>
+    /// <see href="https://resend.com/docs/api-reference/suppressions/remove-suppressions"/>
+    Task<ResendResponse<List<SuppressionRemoveResult>>> SuppressionBatchRemoveAsync( IEnumerable<Guid> suppressionIds, CancellationToken cancellationToken = default );
+
+    #endregion
+
     #region Automations and events
 
     /// <summary>

--- a/src/Resend/Json/JsonStringEnumValue.cs
+++ b/src/Resend/Json/JsonStringEnumValue.cs
@@ -27,8 +27,16 @@ internal static class JsonStringEnumValue<T>
             var str = field.GetCustomAttribute<JsonStringValueAttribute>()?.Value ?? name;
             var val = (T) values.GetValue( i )!;
 
-            fwd.Add( val, str );
-            rev.Add( str, val );
+            // Aliases -- several names sharing one underlying value -- are a legal enum
+            // declaration, so the first name encountered supplies the wire value rather
+            // than the alias making the type unusable.
+            if ( fwd.ContainsKey( val ) == false )
+                fwd.Add( val, str );
+
+            if ( rev.TryGetValue( str, out var prev ) == false )
+                rev.Add( str, val );
+            else if ( EqualityComparer<T>.Default.Equals( prev, val ) == false )
+                throw new InvalidOperationException( $"SE004: '{tt.Name}' maps wire value '{str}' to both '{prev}' and '{val}'" );
         }
 
         Forward = fwd;

--- a/src/Resend/Json/JsonStringEnumValue.cs
+++ b/src/Resend/Json/JsonStringEnumValue.cs
@@ -1,0 +1,63 @@
+using System.Reflection;
+
+namespace Resend;
+
+/// <summary>
+/// Wire values of <typeparamref name="T"/>, as declared by <see cref="JsonStringValueAttribute"/>.
+/// </summary>
+internal static class JsonStringEnumValue<T>
+    where T : struct, Enum
+{
+    /// <summary />
+    static JsonStringEnumValue()
+    {
+        var tt = typeof( T );
+
+        var names = tt.GetEnumNames();
+        var values = tt.GetEnumValues();
+
+        var fwd = new Dictionary<T, string>( names.Length );
+        var rev = new Dictionary<string, T>( names.Length );
+
+        for ( var i = 0; i < names.Length; i++ )
+        {
+            var name = names[ i ];
+            var field = tt.GetField( name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static )!;
+
+            var str = field.GetCustomAttribute<JsonStringValueAttribute>()?.Value ?? name;
+            var val = (T) values.GetValue( i )!;
+
+            fwd.Add( val, str );
+            rev.Add( str, val );
+        }
+
+        Forward = fwd;
+        Reverse = rev;
+    }
+
+
+    /// <summary />
+    public static IReadOnlyDictionary<T, string> Forward { get; }
+
+
+    /// <summary />
+    public static IReadOnlyDictionary<string, T> Reverse { get; }
+
+
+    /// <summary>
+    /// Wire value of <paramref name="value"/>, for use outside of JSON serialization -- eg. in
+    /// query string parameters.
+    /// </summary>
+    /// <param name="value">Enumeration value.</param>
+    /// <returns>Wire value.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="value"/> is not a member of <typeparamref name="T"/>.
+    /// </exception>
+    public static string Of( T value )
+    {
+        if ( Forward.TryGetValue( value, out var str ) == false )
+            throw new ArgumentOutOfRangeException( nameof( value ), $"Invalid '{typeof( T ).Name}' value: '{value}'" );
+
+        return str;
+    }
+}

--- a/src/Resend/Json/JsonStringEnumValueConverter.cs
+++ b/src/Resend/Json/JsonStringEnumValueConverter.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection;
-using System.Text.Json;
+﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Resend;
@@ -8,38 +7,6 @@ namespace Resend;
 public class JsonStringEnumValueConverter<T> : JsonConverter<T>
     where T : struct, Enum
 {
-    private readonly Dictionary<T, string> _fwd;
-    private readonly Dictionary<string, T> _rev;
-
-
-    /// <summary />
-    public JsonStringEnumValueConverter()
-    {
-        var tt = typeof( T );
-
-        var names = tt.GetEnumNames();
-        var values = tt.GetEnumValues();
-
-        var fwd = new Dictionary<T, string>( names.Length );
-        var rev = new Dictionary<string, T>( names.Length );
-
-        for ( var i = 0; i < names.Length; i++ )
-        {
-            var name = names[ i ];
-            var field = tt.GetField( name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static )!;
-
-            var str = field.GetCustomAttribute<JsonStringValueAttribute>()?.Value ?? name;
-            var val = (T) values.GetValue( i )!;
-
-            fwd.Add( val, str );
-            rev.Add( str, val );
-        }
-
-        _fwd = fwd;
-        _rev = rev;
-    }
-
-
     /// <inheritdoc />
     public override T Read( ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options )
     {
@@ -52,7 +19,7 @@ public class JsonStringEnumValueConverter<T> : JsonConverter<T>
         /*
          * 
          */
-        if ( _rev.TryGetValue( json, out var rev ) == false )
+        if ( JsonStringEnumValue<T>.Reverse.TryGetValue( json, out var rev ) == false )
             throw new JsonException( $"SE002: Invalid value: '{json}'" );
 
         return rev;
@@ -62,10 +29,8 @@ public class JsonStringEnumValueConverter<T> : JsonConverter<T>
     /// <inheritdoc />
     public override void Write( Utf8JsonWriter writer, T value, JsonSerializerOptions options )
     {
-        if ( _fwd.ContainsKey( value ) == false )
+        if ( JsonStringEnumValue<T>.Forward.TryGetValue( value, out var str ) == false )
             throw new JsonException( $"SE003: Invalid '{typeof( T ).Name}' value: '{value}'" );
-
-        var str = _fwd[ value ];
 
         writer.WriteStringValue( str );
     }

--- a/src/Resend/Payloads/SuppressionAddRequest.cs
+++ b/src/Resend/Payloads/SuppressionAddRequest.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Resend.Payloads;
+
+/// <summary>
+/// Request object to add a suppression.
+/// </summary>
+public class SuppressionAddRequest
+{
+    /// <summary>
+    /// Email address to suppress.
+    /// </summary>
+    [JsonPropertyName( "email" )]
+    public string Email { get; set; } = default!;
+}

--- a/src/Resend/Payloads/SuppressionBatchAddRequest.cs
+++ b/src/Resend/Payloads/SuppressionBatchAddRequest.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Resend.Payloads;
+
+/// <summary>
+/// Request object to add up to 100 suppressions at once.
+/// </summary>
+public class SuppressionBatchAddRequest
+{
+    /// <summary>
+    /// Email addresses to suppress.
+    /// </summary>
+    [JsonPropertyName( "emails" )]
+    public List<string> Emails { get; set; } = default!;
+}

--- a/src/Resend/Payloads/SuppressionBatchRemoveRequest.cs
+++ b/src/Resend/Payloads/SuppressionBatchRemoveRequest.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace Resend.Payloads;
+
+/// <summary>
+/// Request object to remove up to 100 suppressions at once.
+/// </summary>
+/// <remarks>
+/// The API accepts either <see cref="Emails"/> or <see cref="Ids"/>, never both, and
+/// rejects an explicit null -- hence the unset one is omitted from the payload rather
+/// than written as null.
+/// </remarks>
+public class SuppressionBatchRemoveRequest
+{
+    /// <summary>
+    /// Email addresses to remove from the suppression list.
+    /// </summary>
+    [JsonPropertyName( "emails" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public List<string>? Emails { get; set; }
+
+    /// <summary>
+    /// Suppression identifiers to remove from the suppression list.
+    /// </summary>
+    [JsonPropertyName( "ids" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public List<Guid>? Ids { get; set; }
+}

--- a/src/Resend/ResendClient.Suppressions.cs
+++ b/src/Resend/ResendClient.Suppressions.cs
@@ -1,0 +1,125 @@
+using Microsoft.AspNetCore.WebUtilities;
+using Resend.Payloads;
+using System.Net.Http.Json;
+
+namespace Resend;
+
+public partial class ResendClient
+{
+    /// <inheritdoc />
+    public Task<ResendResponse<Guid>> SuppressionAddAsync( string email, CancellationToken cancellationToken = default )
+    {
+        var req = new HttpRequestMessage( HttpMethod.Post, "/suppressions" );
+        req.Content = JsonContent.Create( new SuppressionAddRequest()
+        {
+            Email = email,
+        } );
+
+        return Execute<ObjectId, Guid>( req, ( x ) => x.Id, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
+    public Task<ResendResponse<PaginatedResult<SuppressionSummary>>> SuppressionListAsync( SuppressionListQuery? query = null, CancellationToken cancellationToken = default )
+    {
+        var baseUrl = "/suppressions";
+        var url = baseUrl;
+
+        if ( query != null )
+        {
+            var qs = new Dictionary<string, string?>();
+
+            if ( query.Limit.HasValue == true )
+                qs.Add( "limit", query.Limit.Value.ToString() );
+
+            if ( query.Before != null )
+                qs.Add( "before", query.Before );
+
+            if ( query.After != null )
+                qs.Add( "after", query.After );
+
+            if ( query.Origin.HasValue == true )
+                qs.Add( "origin", OriginToQueryValue( query.Origin.Value ) );
+
+            url = QueryHelpers.AddQueryString( baseUrl, qs );
+        }
+
+        var req = new HttpRequestMessage( HttpMethod.Get, url );
+
+        return Execute<PaginatedResult<SuppressionSummary>, PaginatedResult<SuppressionSummary>>( req, ( x ) => x, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
+    public Task<ResendResponse<Suppression>> SuppressionRetrieveAsync( string suppressionIdOrEmail, CancellationToken cancellationToken = default )
+    {
+        var req = new HttpRequestMessage( HttpMethod.Get, $"/suppressions/{Uri.EscapeDataString( suppressionIdOrEmail )}" );
+
+        return Execute<Suppression, Suppression>( req, ( x ) => x, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
+    public Task<ResendResponse<SuppressionRemoveResult>> SuppressionRemoveAsync( string suppressionIdOrEmail, CancellationToken cancellationToken = default )
+    {
+        var req = new HttpRequestMessage( HttpMethod.Delete, $"/suppressions/{Uri.EscapeDataString( suppressionIdOrEmail )}" );
+
+        return Execute<SuppressionRemoveResult, SuppressionRemoveResult>( req, ( x ) => x, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
+    public Task<ResendResponse<List<Guid>>> SuppressionBatchAddAsync( IEnumerable<string> emails, CancellationToken cancellationToken = default )
+    {
+        var req = new HttpRequestMessage( HttpMethod.Post, "/suppressions/batch/add" );
+        req.Content = JsonContent.Create( new SuppressionBatchAddRequest()
+        {
+            Emails = emails.ToList(),
+        } );
+
+        return Execute<ListOf<ObjectId>, List<Guid>>( req, ( x ) => x.Data.Select( y => y.Id ).ToList(), cancellationToken );
+    }
+
+
+    /// <inheritdoc />
+    public Task<ResendResponse<List<SuppressionRemoveResult>>> SuppressionBatchRemoveAsync( IEnumerable<string> emails, CancellationToken cancellationToken = default )
+    {
+        return SuppressionBatchRemoveAsync( new SuppressionBatchRemoveRequest()
+        {
+            Emails = emails.ToList(),
+        }, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
+    public Task<ResendResponse<List<SuppressionRemoveResult>>> SuppressionBatchRemoveAsync( IEnumerable<Guid> suppressionIds, CancellationToken cancellationToken = default )
+    {
+        return SuppressionBatchRemoveAsync( new SuppressionBatchRemoveRequest()
+        {
+            Ids = suppressionIds.ToList(),
+        }, cancellationToken );
+    }
+
+
+    /// <summary />
+    private Task<ResendResponse<List<SuppressionRemoveResult>>> SuppressionBatchRemoveAsync( SuppressionBatchRemoveRequest data, CancellationToken cancellationToken )
+    {
+        var req = new HttpRequestMessage( HttpMethod.Post, "/suppressions/batch/remove" );
+        req.Content = JsonContent.Create( data );
+
+        return Execute<ListOf<SuppressionRemoveResult>, List<SuppressionRemoveResult>>( req, ( x ) => x.Data, cancellationToken );
+    }
+
+
+    /// <summary />
+    private static string OriginToQueryValue( SuppressionOrigin origin )
+    {
+        return origin switch
+        {
+            SuppressionOrigin.Bounce => "bounce",
+            SuppressionOrigin.Complaint => "complaint",
+            SuppressionOrigin.Manual => "manual",
+            _ => throw new NotImplementedException( $"Suppression origin {origin} is not implemented" )
+        };
+    }
+}

--- a/src/Resend/ResendClient.Suppressions.cs
+++ b/src/Resend/ResendClient.Suppressions.cs
@@ -39,7 +39,7 @@ public partial class ResendClient
                 qs.Add( "after", query.After );
 
             if ( query.Origin.HasValue == true )
-                qs.Add( "origin", OriginToQueryValue( query.Origin.Value ) );
+                qs.Add( "origin", JsonStringEnumValue<SuppressionOrigin>.Of( query.Origin.Value ) );
 
             url = QueryHelpers.AddQueryString( baseUrl, qs );
         }
@@ -53,6 +53,12 @@ public partial class ResendClient
     /// <inheritdoc />
     public Task<ResendResponse<Suppression>> SuppressionRetrieveAsync( string suppressionIdOrEmail, CancellationToken cancellationToken = default )
     {
+        /*
+         * An empty identifier would target the collection endpoint, which answers with a
+         * list that deserializes into an all-default Suppression instead of failing.
+         */
+        ArgumentException.ThrowIfNullOrWhiteSpace( suppressionIdOrEmail );
+
         var req = new HttpRequestMessage( HttpMethod.Get, $"/suppressions/{Uri.EscapeDataString( suppressionIdOrEmail )}" );
 
         return Execute<Suppression, Suppression>( req, ( x ) => x, cancellationToken );
@@ -62,6 +68,8 @@ public partial class ResendClient
     /// <inheritdoc />
     public Task<ResendResponse<SuppressionRemoveResult>> SuppressionRemoveAsync( string suppressionIdOrEmail, CancellationToken cancellationToken = default )
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace( suppressionIdOrEmail );
+
         var req = new HttpRequestMessage( HttpMethod.Delete, $"/suppressions/{Uri.EscapeDataString( suppressionIdOrEmail )}" );
 
         return Execute<SuppressionRemoveResult, SuppressionRemoveResult>( req, ( x ) => x, cancellationToken );
@@ -108,18 +116,5 @@ public partial class ResendClient
         req.Content = JsonContent.Create( data );
 
         return Execute<ListOf<SuppressionRemoveResult>, List<SuppressionRemoveResult>>( req, ( x ) => x.Data, cancellationToken );
-    }
-
-
-    /// <summary />
-    private static string OriginToQueryValue( SuppressionOrigin origin )
-    {
-        return origin switch
-        {
-            SuppressionOrigin.Bounce => "bounce",
-            SuppressionOrigin.Complaint => "complaint",
-            SuppressionOrigin.Manual => "manual",
-            _ => throw new NotImplementedException( $"Suppression origin {origin} is not implemented" )
-        };
     }
 }

--- a/src/Resend/Suppression.cs
+++ b/src/Resend/Suppression.cs
@@ -1,0 +1,59 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// An email address that is suppressed, and to which Resend will not deliver.
+/// </summary>
+/// <remarks>
+/// Returned when retrieving a single suppression. The list endpoint returns
+/// <see cref="SuppressionSummary"/>, which omits <see cref="Object"/>.
+/// </remarks>
+/// <see href="https://resend.com/docs/api-reference/suppressions/get-suppression" />
+public class Suppression
+{
+    /// <summary>
+    /// Object type discriminator.
+    /// </summary>
+    [JsonPropertyName( "object" )]
+    public string Object { get; set; } = default!;
+
+    /// <summary>
+    /// Suppression identifier.
+    /// </summary>
+    [JsonPropertyName( "id" )]
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Email address that is suppressed.
+    /// </summary>
+    [JsonPropertyName( "email" )]
+    public string Email { get; set; } = default!;
+
+    /// <summary>
+    /// Origin of the suppression.
+    /// </summary>
+    [JsonPropertyName( "origin" )]
+    public SuppressionOrigin Origin { get; set; }
+
+    /// <summary>
+    /// Identifier of the event that caused the suppression, such as the email
+    /// that bounced or was marked as spam.
+    /// </summary>
+    /// <remarks>
+    /// Null for suppressions of <see cref="SuppressionOrigin.Manual"/> origin. Typed as a
+    /// string rather than a <see cref="Guid"/> because the underlying column is free-text:
+    /// it holds an email identifier today, but nothing at the API or database layer
+    /// constrains it, and a non-UUID value would otherwise fail to deserialize.
+    /// </remarks>
+    [JsonPropertyName( "source_id" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? SourceId { get; set; }
+
+    /// <summary>
+    /// Moment when the suppression was created.
+    /// </summary>
+    [JsonPropertyName( "created_at" )]
+    [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
+    public DateTime MomentCreated { get; set; }
+}

--- a/src/Resend/SuppressionListQuery.cs
+++ b/src/Resend/SuppressionListQuery.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// Query parameters for <see cref="IResend.SuppressionListAsync"/>.
+/// </summary>
+public class SuppressionListQuery : PaginatedQuery
+{
+    /// <summary>
+    /// Filter by the origin of the suppression.
+    /// </summary>
+    [JsonIgnore]
+    public SuppressionOrigin? Origin { get; set; }
+}

--- a/src/Resend/SuppressionListQuery.cs
+++ b/src/Resend/SuppressionListQuery.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Resend;
 
 /// <summary>
@@ -10,6 +8,5 @@ public class SuppressionListQuery : PaginatedQuery
     /// <summary>
     /// Filter by the origin of the suppression.
     /// </summary>
-    [JsonIgnore]
     public SuppressionOrigin? Origin { get; set; }
 }

--- a/src/Resend/SuppressionOrigin.cs
+++ b/src/Resend/SuppressionOrigin.cs
@@ -1,0 +1,29 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// Origin of a suppression.
+/// </summary>
+/// <see href="https://resend.com/docs/api-reference/suppressions/list-suppressions" />
+[JsonConverter( typeof( JsonStringEnumValueConverter<SuppressionOrigin> ) )]
+public enum SuppressionOrigin
+{
+    /// <summary>
+    /// Suppression was created because an email to the address bounced.
+    /// </summary>
+    [JsonStringValue( "bounce" )]
+    Bounce,
+
+    /// <summary>
+    /// Suppression was created because the recipient marked an email as spam.
+    /// </summary>
+    [JsonStringValue( "complaint" )]
+    Complaint,
+
+    /// <summary>
+    /// Suppression was created manually.
+    /// </summary>
+    [JsonStringValue( "manual" )]
+    Manual,
+}

--- a/src/Resend/SuppressionRemoveResult.cs
+++ b/src/Resend/SuppressionRemoveResult.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// Outcome of removing a suppression.
+/// </summary>
+public class SuppressionRemoveResult
+{
+    /// <summary>
+    /// Object type discriminator.
+    /// </summary>
+    [JsonPropertyName( "object" )]
+    public string Object { get; set; } = default!;
+
+    /// <summary>
+    /// Suppression identifier.
+    /// </summary>
+    [JsonPropertyName( "id" )]
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Whether the suppression was removed.
+    /// </summary>
+    [JsonPropertyName( "deleted" )]
+    public bool Deleted { get; set; }
+}

--- a/src/Resend/SuppressionSummary.cs
+++ b/src/Resend/SuppressionSummary.cs
@@ -1,0 +1,54 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// A suppressed email address, as returned by the suppression list.
+/// </summary>
+/// <remarks>
+/// The list endpoint does not return the <c>object</c> discriminator that
+/// <see cref="Suppression"/> carries; the two shapes are otherwise identical.
+/// </remarks>
+/// <see href="https://resend.com/docs/api-reference/suppressions/list-suppressions" />
+public class SuppressionSummary
+{
+    /// <summary>
+    /// Suppression identifier.
+    /// </summary>
+    [JsonPropertyName( "id" )]
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Email address that is suppressed.
+    /// </summary>
+    [JsonPropertyName( "email" )]
+    public string Email { get; set; } = default!;
+
+    /// <summary>
+    /// Origin of the suppression.
+    /// </summary>
+    [JsonPropertyName( "origin" )]
+    public SuppressionOrigin Origin { get; set; }
+
+    /// <summary>
+    /// Identifier of the event that caused the suppression, such as the email
+    /// that bounced or was marked as spam.
+    /// </summary>
+    /// <remarks>
+    /// Null for suppressions of <see cref="SuppressionOrigin.Manual"/> origin. Typed as a
+    /// string rather than a <see cref="Guid"/> because the underlying column is free-text:
+    /// it holds an email identifier today, but nothing at the API or database layer
+    /// constrains it, and a non-UUID value would otherwise fail to deserialize -- which on
+    /// a list response would throw away the entire page, not just one entry.
+    /// </remarks>
+    [JsonPropertyName( "source_id" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public string? SourceId { get; set; }
+
+    /// <summary>
+    /// Moment when the suppression was created.
+    /// </summary>
+    [JsonPropertyName( "created_at" )]
+    [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
+    public DateTime MomentCreated { get; set; }
+}

--- a/tests/Resend.Tests/JsonStringEnumValueTests.cs
+++ b/tests/Resend.Tests/JsonStringEnumValueTests.cs
@@ -38,6 +38,63 @@ public class JsonStringEnumValueTests
 
 
     /// <summary />
+    [JsonConverter( typeof( JsonStringEnumValueConverter<AliasedEnum> ) )]
+    public enum AliasedEnum
+    {
+        /// <summary />
+        [JsonStringValue( "current" )]
+        Current = 1,
+
+        /// <summary />
+        [JsonStringValue( "legacy" )]
+        Legacy = 1,
+
+        /// <summary />
+        [JsonStringValue( "other" )]
+        Other = 2,
+    }
+
+
+    /// <summary />
+    [JsonConverter( typeof( JsonStringEnumValueConverter<ConflictingEnum> ) )]
+    public enum ConflictingEnum
+    {
+        /// <summary />
+        [JsonStringValue( "same" )]
+        First = 1,
+
+        /// <summary />
+        [JsonStringValue( "same" )]
+        Second = 2,
+    }
+
+
+    /// <summary />
+    [Fact]
+    public void AliasIsUsable()
+    {
+        var json = JsonSerializer.Serialize( AliasedEnum.Current );
+        Assert.Contains( json, new[] { "\"current\"", "\"legacy\"" } );
+
+        Assert.Equal( AliasedEnum.Current, JsonSerializer.Deserialize<AliasedEnum>( "\"current\"" ) );
+        Assert.Equal( AliasedEnum.Current, JsonSerializer.Deserialize<AliasedEnum>( "\"legacy\"" ) );
+        Assert.Equal( AliasedEnum.Other, JsonSerializer.Deserialize<AliasedEnum>( "\"other\"" ) );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public void ConflictingWireValueThrows()
+    {
+        Action act = () => JsonSerializer.Serialize( ConflictingEnum.First );
+
+        var ex = Assert.Throws<TypeInitializationException>( act );
+        Assert.NotNull( ex.InnerException );
+        Assert.StartsWith( "SE004:", ex.InnerException.Message );
+    }
+
+
+    /// <summary />
     [Fact]
     public void WithAttribute()
     {

--- a/tests/Resend.Tests/ResendClientTests.Suppressions.cs
+++ b/tests/Resend.Tests/ResendClientTests.Suppressions.cs
@@ -1,3 +1,5 @@
+using System.Net;
+
 namespace Resend.Tests;
 
 /// <summary />
@@ -155,6 +157,25 @@ public partial class ResendClientTests
     }
 
 
+    /// <summary>
+    /// The API validates each entry, so a blank one fails the whole batch.
+    /// </summary>
+    [Theory]
+    [InlineData( null )]
+    [InlineData( "   " )]
+    public async Task SuppressionBatchAddRejectsBlankEntry( string? email )
+    {
+        var ex = await Assert.ThrowsAsync<ResendException>( () => _resend.SuppressionBatchAddAsync( new[]
+        {
+            "steve.wozniak@gmail.com",
+            email!,
+        } ) );
+
+        Assert.Equal( HttpStatusCode.UnprocessableEntity, ex.StatusCode );
+        Assert.Equal( ErrorType.ValidationError, ex.ErrorType );
+    }
+
+
     /// <summary />
     [Fact]
     public async Task SuppressionBatchRemoveByEmail()
@@ -186,5 +207,22 @@ public partial class ResendClientTests
         Assert.Single( resp.Content );
         Assert.Equal( suppressionId, resp.Content[ 0 ].Id );
         Assert.True( resp.Content[ 0 ].Deleted );
+    }
+
+
+    /// <summary />
+    [Theory]
+    [InlineData( null )]
+    [InlineData( "   " )]
+    public async Task SuppressionBatchRemoveRejectsBlankEntry( string? email )
+    {
+        var ex = await Assert.ThrowsAsync<ResendException>( () => _resend.SuppressionBatchRemoveAsync( new[]
+        {
+            "steve.wozniak@gmail.com",
+            email!,
+        } ) );
+
+        Assert.Equal( HttpStatusCode.UnprocessableEntity, ex.StatusCode );
+        Assert.Equal( ErrorType.ValidationError, ex.ErrorType );
     }
 }

--- a/tests/Resend.Tests/ResendClientTests.Suppressions.cs
+++ b/tests/Resend.Tests/ResendClientTests.Suppressions.cs
@@ -1,0 +1,190 @@
+namespace Resend.Tests;
+
+/// <summary />
+public partial class ResendClientTests
+{
+    /// <summary />
+    [Fact]
+    public async Task SuppressionAdd()
+    {
+        var resp = await _resend.SuppressionAddAsync( "steve.wozniak@gmail.com" );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotEqual( Guid.Empty, resp.Content );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task SuppressionList()
+    {
+        var resp = await _resend.SuppressionListAsync( new SuppressionListQuery()
+        {
+            Limit = 20,
+            After = Guid.NewGuid().ToString(),
+        } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.True( resp.Content.HasMore );
+        Assert.Single( resp.Content.Data );
+        Assert.Equal( "steve.wozniak@gmail.com", resp.Content.Data[ 0 ].Email );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task SuppressionListByOrigin()
+    {
+        var resp = await _resend.SuppressionListAsync( new SuppressionListQuery()
+        {
+            Origin = SuppressionOrigin.Bounce,
+        } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( SuppressionOrigin.Bounce, resp.Content.Data[ 0 ].Origin );
+        Assert.NotNull( resp.Content.Data[ 0 ].SourceId );
+    }
+
+
+    /// <summary>
+    /// Manual-origin suppressions carry no source_id.
+    /// </summary>
+    [Fact]
+    public async Task SuppressionListManualHasNoSourceId()
+    {
+        var resp = await _resend.SuppressionListAsync( new SuppressionListQuery()
+        {
+            Origin = SuppressionOrigin.Manual,
+        } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( SuppressionOrigin.Manual, resp.Content.Data[ 0 ].Origin );
+        Assert.Null( resp.Content.Data[ 0 ].SourceId );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task SuppressionRetrieveById()
+    {
+        var suppressionId = Guid.NewGuid();
+
+        var resp = await _resend.SuppressionRetrieveAsync( suppressionId.ToString() );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( suppressionId, resp.Content.Id );
+        Assert.Equal( "suppression", resp.Content.Object );
+    }
+
+
+    /// <summary>
+    /// The path parameter accepts an email address, which must survive URL-encoding.
+    /// </summary>
+    [Fact]
+    public async Task SuppressionRetrieveByEmail()
+    {
+        var resp = await _resend.SuppressionRetrieveAsync( "steve+woz@example.com" );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( "steve+woz@example.com", resp.Content.Email );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task SuppressionRemove()
+    {
+        var suppressionId = Guid.NewGuid();
+
+        var resp = await _resend.SuppressionRemoveAsync( suppressionId.ToString() );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( suppressionId, resp.Content.Id );
+        Assert.True( resp.Content.Deleted );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task SuppressionBatchAdd()
+    {
+        var resp = await _resend.SuppressionBatchAddAsync( new[]
+        {
+            "steve.wozniak@gmail.com",
+            "steve+woz@example.com",
+        } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( 2, resp.Content.Count );
+        Assert.All( resp.Content, ( x ) => Assert.NotEqual( Guid.Empty, x ) );
+    }
+
+
+    /// <summary>
+    /// The API lowercases, trims and dedupes addresses, so the response can be shorter than
+    /// the request and must not be paired with the input by index.
+    /// </summary>
+    [Fact]
+    public async Task SuppressionBatchAddDedupesCaseVariants()
+    {
+        var resp = await _resend.SuppressionBatchAddAsync( new[]
+        {
+            "CAROLINA+suppressed@resend.com",
+            "carolina+suppressed@resend.com",
+        } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Single( resp.Content );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task SuppressionBatchRemoveByEmail()
+    {
+        var resp = await _resend.SuppressionBatchRemoveAsync( new[]
+        {
+            "steve.wozniak@gmail.com",
+        } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Single( resp.Content );
+        Assert.True( resp.Content[ 0 ].Deleted );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task SuppressionBatchRemoveById()
+    {
+        var suppressionId = Guid.NewGuid();
+
+        var resp = await _resend.SuppressionBatchRemoveAsync( new[] { suppressionId } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Single( resp.Content );
+        Assert.Equal( suppressionId, resp.Content[ 0 ].Id );
+        Assert.True( resp.Content[ 0 ].Deleted );
+    }
+}

--- a/tests/Resend.Tests/SuppressionRequestTests.cs
+++ b/tests/Resend.Tests/SuppressionRequestTests.cs
@@ -1,0 +1,89 @@
+using System.Net;
+using System.Text;
+
+namespace Resend.Tests;
+
+/// <summary>
+/// Tests over the requests issued by the suppression methods, against a handler which records
+/// instead of answering like the API.
+/// </summary>
+public class SuppressionRequestTests
+{
+    private readonly RecordingHandler _handler;
+    private readonly IResend _resend;
+
+
+    /// <summary />
+    public SuppressionRequestTests()
+    {
+        _handler = new RecordingHandler();
+
+        var opt = new ResendClientOptions()
+        {
+            ApiToken = "re_test_123",
+        };
+
+        _resend = ResendClient.Create( opt, new HttpClient( _handler ) );
+    }
+
+
+    /// <summary />
+    [Theory]
+    [InlineData( SuppressionOrigin.Bounce, "bounce" )]
+    [InlineData( SuppressionOrigin.Complaint, "complaint" )]
+    [InlineData( SuppressionOrigin.Manual, "manual" )]
+    public async Task SuppressionList_Origin( SuppressionOrigin origin, string expected )
+    {
+        await _resend.SuppressionListAsync( new SuppressionListQuery()
+        {
+            Origin = origin,
+        } );
+
+        var req = Assert.Single( _handler.Requests );
+        Assert.Equal( $"/suppressions?origin={expected}", req.RequestUri!.PathAndQuery );
+    }
+
+
+    /// <summary />
+    [Theory]
+    [InlineData( "" )]
+    [InlineData( "  " )]
+    public async Task SuppressionRetrieve_Blank_Throws( string suppressionIdOrEmail )
+    {
+        await Assert.ThrowsAsync<ArgumentException>( () => _resend.SuppressionRetrieveAsync( suppressionIdOrEmail ) );
+
+        Assert.Empty( _handler.Requests );
+    }
+
+
+    /// <summary />
+    [Theory]
+    [InlineData( "" )]
+    [InlineData( "  " )]
+    public async Task SuppressionRemove_Blank_Throws( string suppressionIdOrEmail )
+    {
+        await Assert.ThrowsAsync<ArgumentException>( () => _resend.SuppressionRemoveAsync( suppressionIdOrEmail ) );
+
+        Assert.Empty( _handler.Requests );
+    }
+
+
+    /// <summary />
+    private class RecordingHandler : HttpMessageHandler
+    {
+        /// <summary />
+        public List<HttpRequestMessage> Requests { get; } = new();
+
+
+        /// <inheritdoc />
+        protected override Task<HttpResponseMessage> SendAsync( HttpRequestMessage request, CancellationToken cancellationToken )
+        {
+            Requests.Add( request );
+
+            var resp = new HttpResponseMessage( HttpStatusCode.OK );
+            resp.Content = new StringContent( """{"has_more":false,"data":[]}""", Encoding.UTF8, "application/json" );
+
+            return Task.FromResult( resp );
+        }
+    }
+}

--- a/tests/Resend.Tests/SuppressionTests.cs
+++ b/tests/Resend.Tests/SuppressionTests.cs
@@ -1,0 +1,387 @@
+using Resend.Payloads;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace Resend.Tests;
+
+/// <summary />
+public class SuppressionTests
+{
+    /// <summary />
+    [Fact]
+    public void Suppression_deserializes_documented_payload()
+    {
+        const string json = """
+            {
+              "object": "suppression",
+              "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+              "email": "steve.wozniak@gmail.com",
+              "origin": "bounce",
+              "source_id": "479e3145-dd38-476b-932c-529ceb705947",
+              "created_at": "2023-10-06T23:47:56.678Z"
+            }
+            """;
+
+        var suppression = JsonSerializer.Deserialize<Suppression>( json );
+
+        Assert.NotNull( suppression );
+        Assert.Equal( "suppression", suppression!.Object );
+        Assert.Equal( Guid.Parse( "e169aa45-1ecf-4183-9955-b1499d5701d3" ), suppression.Id );
+        Assert.Equal( "steve.wozniak@gmail.com", suppression.Email );
+        Assert.Equal( SuppressionOrigin.Bounce, suppression.Origin );
+        Assert.Equal( "479e3145-dd38-476b-932c-529ceb705947", suppression.SourceId );
+    }
+
+
+    /// <summary>
+    /// source_id is a free-text column, so a non-UUID value must not fail deserialization.
+    /// </summary>
+    [Fact]
+    public void Suppression_deserializes_non_uuid_source_id()
+    {
+        const string json = """
+            {
+              "object": "suppression",
+              "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+              "email": "steve.wozniak@gmail.com",
+              "origin": "bounce",
+              "source_id": "backfill-2026-07",
+              "created_at": "2023-10-06T23:47:56.678Z"
+            }
+            """;
+
+        var suppression = JsonSerializer.Deserialize<Suppression>( json );
+
+        Assert.NotNull( suppression );
+        Assert.Equal( "backfill-2026-07", suppression!.SourceId );
+    }
+
+
+    /// <summary>
+    /// A non-UUID source_id on one list entry would otherwise throw away the whole page.
+    /// </summary>
+    [Fact]
+    public void SuppressionList_deserializes_non_uuid_source_id()
+    {
+        const string json = """
+            {
+              "object": "list",
+              "has_more": false,
+              "data": [
+                {
+                  "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+                  "email": "steve.wozniak@gmail.com",
+                  "origin": "bounce",
+                  "source_id": "backfill-2026-07",
+                  "created_at": "2023-10-06T23:47:56.678Z"
+                },
+                {
+                  "id": "8d1f0f4a-2b6e-4c3d-9f1a-0e5b7c9d2a11",
+                  "email": "carolina@resend.com",
+                  "origin": "manual",
+                  "source_id": null,
+                  "created_at": "2023-10-06T23:47:56.678Z"
+                }
+              ]
+            }
+            """;
+
+        var page = JsonSerializer.Deserialize<PaginatedResult<SuppressionSummary>>( json );
+
+        Assert.NotNull( page );
+        Assert.Equal( 2, page!.Data.Count );
+        Assert.Equal( "backfill-2026-07", page.Data[ 0 ].SourceId );
+        Assert.Null( page.Data[ 1 ].SourceId );
+    }
+
+
+    /// <summary>
+    /// source_id is null for manual-origin suppressions.
+    /// </summary>
+    [Fact]
+    public void Suppression_deserializes_null_source_id()
+    {
+        const string json = """
+            {
+              "object": "suppression",
+              "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+              "email": "steve.wozniak@gmail.com",
+              "origin": "manual",
+              "source_id": null,
+              "created_at": "2023-10-06T23:47:56.678Z"
+            }
+            """;
+
+        var suppression = JsonSerializer.Deserialize<Suppression>( json );
+
+        Assert.NotNull( suppression );
+        Assert.Equal( SuppressionOrigin.Manual, suppression!.Origin );
+        Assert.Null( suppression.SourceId );
+    }
+
+
+    /// <summary>
+    /// A missing source_id key must deserialize as cleanly as an explicit null.
+    /// </summary>
+    [Fact]
+    public void Suppression_deserializes_missing_source_id()
+    {
+        const string json = """
+            {
+              "object": "suppression",
+              "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+              "email": "steve.wozniak@gmail.com",
+              "origin": "complaint",
+              "created_at": "2023-10-06T23:47:56.678Z"
+            }
+            """;
+
+        var suppression = JsonSerializer.Deserialize<Suppression>( json );
+
+        Assert.NotNull( suppression );
+        Assert.Null( suppression!.SourceId );
+        Assert.Equal( SuppressionOrigin.Complaint, suppression.Origin );
+    }
+
+
+    /// <summary>
+    /// created_at is a Postgres timestamptz read in string mode, so the wire value is not
+    /// strict ISO 8601 -- space separator and a two-digit offset must still parse.
+    /// </summary>
+    [Fact]
+    public void Suppression_deserializes_postgres_timestamp()
+    {
+        const string json = """
+            {
+              "object": "suppression",
+              "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+              "email": "steve.wozniak@gmail.com",
+              "origin": "manual",
+              "source_id": null,
+              "created_at": "2026-07-24 18:30:00.123456+00"
+            }
+            """;
+
+        var suppression = JsonSerializer.Deserialize<Suppression>( json );
+
+        Assert.NotNull( suppression );
+        Assert.Equal( DateTimeKind.Utc, suppression!.MomentCreated.Kind );
+        Assert.Equal( new DateOnly( 2026, 7, 24 ), DateOnly.FromDateTime( suppression.MomentCreated ) );
+        Assert.Equal( 18, suppression.MomentCreated.Hour );
+        Assert.Equal( 30, suppression.MomentCreated.Minute );
+    }
+
+
+    /// <summary>
+    /// The same non-ISO wire format arrives on list entries.
+    /// </summary>
+    [Fact]
+    public void SuppressionSummary_deserializes_postgres_timestamp()
+    {
+        const string json = """
+            {
+              "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+              "email": "steve.wozniak@gmail.com",
+              "origin": "manual",
+              "source_id": null,
+              "created_at": "2026-07-24 18:30:00.123456+00"
+            }
+            """;
+
+        var entry = JsonSerializer.Deserialize<SuppressionSummary>( json );
+
+        Assert.NotNull( entry );
+        Assert.Equal( DateTimeKind.Utc, entry!.MomentCreated.Kind );
+        Assert.Equal( 2026, entry.MomentCreated.Year );
+        Assert.Equal( 18, entry.MomentCreated.Hour );
+    }
+
+
+    /// <summary>
+    /// Real payloads do not guarantee property order; deserialization must not depend on it.
+    /// </summary>
+    [Fact]
+    public void Suppression_deserializes_out_of_order()
+    {
+        const string json = """
+            {
+              "created_at": "2023-10-06T23:47:56.678Z",
+              "source_id": null,
+              "origin": "manual",
+              "email": "steve.wozniak@gmail.com",
+              "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+              "object": "suppression"
+            }
+            """;
+
+        var suppression = JsonSerializer.Deserialize<Suppression>( json );
+
+        Assert.NotNull( suppression );
+        Assert.Equal( SuppressionOrigin.Manual, suppression!.Origin );
+        Assert.Equal( "steve.wozniak@gmail.com", suppression.Email );
+        Assert.Equal( Guid.Parse( "e169aa45-1ecf-4183-9955-b1499d5701d3" ), suppression.Id );
+    }
+
+
+    /// <summary>
+    /// The list endpoint selects exactly id/email/origin/source_id/created_at -- entries
+    /// carry no `object` discriminator, unlike the single-suppression response.
+    /// </summary>
+    [Fact]
+    public void SuppressionList_deserializes_server_payload()
+    {
+        const string json = """
+            {
+              "object": "list",
+              "has_more": false,
+              "data": [
+                {
+                  "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+                  "email": "steve.wozniak@gmail.com",
+                  "origin": "manual",
+                  "source_id": null,
+                  "created_at": "2023-10-06T23:47:56.678Z"
+                }
+              ]
+            }
+            """;
+
+        var page = JsonSerializer.Deserialize<PaginatedResult<SuppressionSummary>>( json );
+
+        Assert.NotNull( page );
+        Assert.False( page!.HasMore );
+        Assert.Single( page.Data );
+        Assert.Equal( SuppressionOrigin.Manual, page.Data[ 0 ].Origin );
+        Assert.Null( page.Data[ 0 ].SourceId );
+        Assert.Equal( "steve.wozniak@gmail.com", page.Data[ 0 ].Email );
+    }
+
+
+    /// <summary>
+    /// The list entry type must not advertise a property the API never sends.
+    /// </summary>
+    [Fact]
+    public void SuppressionSummary_has_no_object_property()
+    {
+        Assert.Null( typeof( SuppressionSummary ).GetProperty( "Object" ) );
+        Assert.NotNull( typeof( Suppression ).GetProperty( "Object" ) );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public void SuppressionOrigin_serializes_wire_values()
+    {
+        Assert.Equal( "\"bounce\"", JsonSerializer.Serialize( SuppressionOrigin.Bounce ) );
+        Assert.Equal( "\"complaint\"", JsonSerializer.Serialize( SuppressionOrigin.Complaint ) );
+        Assert.Equal( "\"manual\"", JsonSerializer.Serialize( SuppressionOrigin.Manual ) );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public void SuppressionAddRequest_serializes_email()
+    {
+        var request = new SuppressionAddRequest()
+        {
+            Email = "steve.wozniak@gmail.com",
+        };
+
+        var json = JsonSerializer.Serialize( request );
+
+        Assert.Equal( """{"email":"steve.wozniak@gmail.com"}""", json );
+    }
+
+
+    /// <summary>
+    /// Batch remove takes either emails or ids; the API rejects an explicit null, so the
+    /// unset one must be absent from the body.
+    /// </summary>
+    [Fact]
+    public async Task SuppressionBatchRemoveRequest_omits_unset_ids()
+    {
+        var request = new SuppressionBatchRemoveRequest()
+        {
+            Emails = new List<string>() { "steve.wozniak@gmail.com" },
+        };
+
+        using var content = JsonContent.Create( request );
+        var json = await content.ReadAsStringAsync();
+
+        Assert.Contains( "\"emails\":[\"steve.wozniak@gmail.com\"]", json );
+        Assert.DoesNotContain( "ids", json );
+        Assert.DoesNotContain( "null", json );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task SuppressionBatchRemoveRequest_omits_unset_emails()
+    {
+        var request = new SuppressionBatchRemoveRequest()
+        {
+            Ids = new List<Guid>() { Guid.Parse( "e169aa45-1ecf-4183-9955-b1499d5701d3" ) },
+        };
+
+        using var content = JsonContent.Create( request );
+        var json = await content.ReadAsStringAsync();
+
+        Assert.Contains( "\"ids\":[\"e169aa45-1ecf-4183-9955-b1499d5701d3\"]", json );
+        Assert.DoesNotContain( "emails", json );
+        Assert.DoesNotContain( "null", json );
+    }
+
+
+    /// <summary>
+    /// Batch remove returns only the rows actually deleted, so a two-identifier request can
+    /// come back with one entry -- and never a placeholder for the missing one.
+    /// </summary>
+    [Fact]
+    public void SuppressionBatchRemove_deserializes_shorter_response()
+    {
+        const string json = """
+            {
+              "data": [
+                {
+                  "object": "suppression",
+                  "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+                  "deleted": true
+                }
+              ]
+            }
+            """;
+
+        var result = JsonSerializer.Deserialize<ListOf<SuppressionRemoveResult>>( json );
+
+        Assert.NotNull( result );
+        Assert.Single( result!.Data );
+        Assert.Equal( Guid.Parse( "e169aa45-1ecf-4183-9955-b1499d5701d3" ), result.Data[ 0 ].Id );
+        Assert.True( result.Data[ 0 ].Deleted );
+    }
+
+
+    /// <summary>
+    /// Batch add dedupes server-side, so the identifier list can be shorter than the
+    /// addresses sent.
+    /// </summary>
+    [Fact]
+    public void SuppressionBatchAdd_deserializes_shorter_response()
+    {
+        const string json = """
+            {
+              "data": [
+                {
+                  "object": "suppression",
+                  "id": "e169aa45-1ecf-4183-9955-b1499d5701d3"
+                }
+              ]
+            }
+            """;
+
+        var result = JsonSerializer.Deserialize<ListOf<ObjectId>>( json );
+
+        Assert.NotNull( result );
+        Assert.Single( result!.Data );
+        Assert.Equal( Guid.Parse( "e169aa45-1ecf-4183-9955-b1499d5701d3" ), result.Data[ 0 ].Id );
+    }
+}

--- a/tools/Resend.ApiServer/Controllers/SuppressionController.cs
+++ b/tools/Resend.ApiServer/Controllers/SuppressionController.cs
@@ -1,0 +1,143 @@
+using Microsoft.AspNetCore.Mvc;
+using Resend.Payloads;
+
+namespace Resend.ApiServer.Controllers;
+
+/// <summary />
+[ApiController]
+public class SuppressionController : ControllerBase
+{
+    private readonly ILogger<SuppressionController> _logger;
+
+
+    /// <summary />
+    public SuppressionController( ILogger<SuppressionController> logger )
+    {
+        _logger = logger;
+    }
+
+
+    /// <summary />
+    [HttpPost]
+    [Route( "suppressions" )]
+    public ObjectId SuppressionAdd( [FromBody] SuppressionAddRequest request )
+    {
+        _logger.LogDebug( "SuppressionAdd" );
+
+        return new ObjectId()
+        {
+            Object = "suppression",
+            Id = Guid.NewGuid(),
+        };
+    }
+
+
+    /// <summary />
+    [HttpGet]
+    [Route( "suppressions" )]
+    public PaginatedResult<SuppressionSummary> SuppressionList( [FromQuery] string? origin = null )
+    {
+        _logger.LogDebug( "SuppressionList" );
+
+        var list = new List<SuppressionSummary>();
+        list.Add( new SuppressionSummary()
+        {
+            Id = Guid.NewGuid(),
+            Email = "steve.wozniak@gmail.com",
+            Origin = origin switch
+            {
+                "bounce" => SuppressionOrigin.Bounce,
+                "complaint" => SuppressionOrigin.Complaint,
+                _ => SuppressionOrigin.Manual,
+            },
+            SourceId = origin == "bounce" ? Guid.NewGuid().ToString() : null,
+            MomentCreated = DateTime.UtcNow,
+        } );
+
+        return new PaginatedResult<SuppressionSummary>() { HasMore = true, Data = list };
+    }
+
+
+    /// <summary />
+    [HttpGet]
+    [Route( "suppressions/{suppression}" )]
+    public Suppression SuppressionRetrieve( [FromRoute] string suppression )
+    {
+        _logger.LogDebug( "SuppressionRetrieve" );
+
+        var isId = Guid.TryParse( suppression, out var id );
+
+        return new Suppression()
+        {
+            Object = "suppression",
+            Id = isId == true ? id : Guid.NewGuid(),
+            Email = isId == true ? "steve.wozniak@gmail.com" : suppression,
+            Origin = SuppressionOrigin.Manual,
+            MomentCreated = DateTime.UtcNow,
+        };
+    }
+
+
+    /// <summary />
+    [HttpDelete]
+    [Route( "suppressions/{suppression}" )]
+    public SuppressionRemoveResult SuppressionRemove( [FromRoute] string suppression )
+    {
+        _logger.LogDebug( "SuppressionRemove" );
+
+        return new SuppressionRemoveResult()
+        {
+            Object = "suppression",
+            Id = Guid.TryParse( suppression, out var id ) == true ? id : Guid.NewGuid(),
+            Deleted = true,
+        };
+    }
+
+
+    /// <summary />
+    [HttpPost]
+    [Route( "suppressions/batch/add" )]
+    public ListOf<ObjectId> SuppressionBatchAdd( [FromBody] SuppressionBatchAddRequest request )
+    {
+        _logger.LogDebug( "SuppressionBatchAdd" );
+
+        var list = Normalize( request.Emails )
+            .Select( _ => new ObjectId() { Object = "suppression", Id = Guid.NewGuid() } )
+            .ToList();
+
+        return new ListOf<ObjectId>() { Data = list };
+    }
+
+
+    /// <summary />
+    [HttpPost]
+    [Route( "suppressions/batch/remove" )]
+    public ActionResult<ListOf<SuppressionRemoveResult>> SuppressionBatchRemove( [FromBody] SuppressionBatchRemoveRequest request )
+    {
+        _logger.LogDebug( "SuppressionBatchRemove" );
+
+        if ( ( request.Emails == null ) == ( request.Ids == null ) )
+            return BadRequest();
+
+        var ids = request.Ids ?? Normalize( request.Emails! ).Select( _ => Guid.NewGuid() ).ToList();
+
+        var list = ids
+            .Select( x => new SuppressionRemoveResult() { Object = "suppression", Id = x, Deleted = true } )
+            .ToList();
+
+        return new ListOf<SuppressionRemoveResult>() { Data = list };
+    }
+
+
+    /// <summary>
+    /// Mirrors the API, which lowercases, trims and dedupes addresses before writing --
+    /// so a batch response can be shorter than the request.
+    /// </summary>
+    private static List<string> Normalize( IEnumerable<string> emails )
+    {
+        return emails
+            .Select( x => x.ToLowerInvariant().Trim() )
+            .Distinct()
+            .ToList();
+    }
+}

--- a/tools/Resend.ApiServer/Controllers/SuppressionController.cs
+++ b/tools/Resend.ApiServer/Controllers/SuppressionController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Resend.Payloads;
+using System.Net;
 
 namespace Resend.ApiServer.Controllers;
 
@@ -97,9 +98,14 @@ public class SuppressionController : ControllerBase
     /// <summary />
     [HttpPost]
     [Route( "suppressions/batch/add" )]
-    public ListOf<ObjectId> SuppressionBatchAdd( [FromBody] SuppressionBatchAddRequest request )
+    public ActionResult<ListOf<ObjectId>> SuppressionBatchAdd( [FromBody] SuppressionBatchAddRequest request )
     {
         _logger.LogDebug( "SuppressionBatchAdd" );
+
+        var invalid = ValidateEmails( request.Emails );
+
+        if ( invalid != null )
+            return invalid;
 
         var list = Normalize( request.Emails )
             .Select( _ => new ObjectId() { Object = "suppression", Id = Guid.NewGuid() } )
@@ -119,6 +125,14 @@ public class SuppressionController : ControllerBase
         if ( ( request.Emails == null ) == ( request.Ids == null ) )
             return BadRequest();
 
+        if ( request.Emails != null )
+        {
+            var invalid = ValidateEmails( request.Emails );
+
+            if ( invalid != null )
+                return invalid;
+        }
+
         var ids = request.Ids ?? Normalize( request.Emails! ).Select( _ => Guid.NewGuid() ).ToList();
 
         var list = ids
@@ -126,6 +140,24 @@ public class SuppressionController : ControllerBase
             .ToList();
 
         return new ListOf<SuppressionRemoveResult>() { Data = list };
+    }
+
+
+    /// <summary>
+    /// Mirrors the API, which validates every entry as an email address -- a missing or blank
+    /// one is rejected outright rather than dropped from the batch.
+    /// </summary>
+    private ActionResult? ValidateEmails( IEnumerable<string>? emails )
+    {
+        if ( emails != null && emails.Any( x => string.IsNullOrWhiteSpace( x ) ) == false )
+            return null;
+
+        return UnprocessableEntity( new ErrorResponse()
+        {
+            StatusCode = (int) HttpStatusCode.UnprocessableEntity,
+            ErrorType = ErrorType.ValidationError,
+            Message = "Each item in `emails` must be a valid email address.",
+        } );
     }
 
 


### PR DESCRIPTION
## What

Adds suppression-list support to `IResend` / `ResendClient`: `SuppressionAddAsync`, `SuppressionListAsync`, `SuppressionRetrieveAsync`, `SuppressionRemoveAsync`, `SuppressionBatchAddAsync`, `SuppressionBatchRemoveAsync` — all returning `ResendResponse<T>` and taking a `CancellationToken`.

Follows the Domain Claims PR (#133) for structure: partial class `ResendClient.Suppressions.cs`, models in `src/Resend`, request objects under `Payloads`, and the existing `JsonStringEnumValueConverter` + `[JsonStringValue]` pattern for `SuppressionOrigin` (as `DomainClaimStatus` does). Reuses the existing `PaginatedResult<T>` for `has_more`/`data`.

Details worth calling out:
- `SuppressionRetrieveAsync`/`SuppressionRemoveAsync` take a **`string`**, not a `Guid`, because the path parameter accepts an ID *or* an email address (the server does `validator.isUUID()` and treats a non-UUID as an email). Escaped with `Uri.EscapeDataString`.
- Batch remove is expressed as **two overloads** — `IEnumerable<string> emails` and `IEnumerable<Guid> suppressionIds` — which makes the emails-XOR-ids constraint a compile-time guarantee rather than a runtime check. Both payload properties use `JsonIgnoreCondition.WhenWritingNull` so the unset one is omitted.
- `SuppressionSummary` (list entries) and `Suppression` (`get`) are separate types, differing only by `Object`.
- `source_id` is typed `string?`, not `Guid?`: the underlying column is free-text and the spec declares a plain string, so a non-UUID value would otherwise throw and discard an entire list page. `Id` stays `Guid`, which the schema does back.

## Contract verification

Verified in order of authority: the API server implementation (`apps/public-api/src/routes/suppressions/` in the monorepo), then `resend-openapi` `resend.yaml`, then the docs — and finally end-to-end against the live API with a real team key (read-only operations).

**One deliberate divergence, flagged so it does not look like a bug in review:** list entries do **not** carry the `object` field; only the single-`get` response does. `list.ts` selects exactly `{id, email, origin, source_id, created_at}` and adds nothing, while `get.ts` returns `{object: "suppression", ...}`. Confirmed on live wire output.

Two upstream artifacts disagree with the server here and are being tracked separately, so please do not use them as the reference when reviewing:
- the `list-suppressions` docs example shows a per-entry `object` that the API never sends
- `resend-node` `SuppressionListEntry` declares the same nonexistent field, and is shipped in `resend@6.18.0`

The OpenAPI spec is correct on this point and agrees with the implementation.

Other behaviour confirmed at the server and reflected in docs/tests, not reimplemented client-side:
- `batch/remove` accepts `emails` XOR `ids`; the unset key must be **omitted**, since the server validation accepts undefined but rejects an explicit `null`
- the API lowercases, trims and **deduplicates** emails, and `batch/add` upserts — so batch responses can contain **fewer** entries than were sent; callers must not pair results to inputs by index
- `batch/remove` returns only rows actually deleted (misses are absent, no error), whereas single `remove` returns 404 on a miss
- `source_id` is nullable and is `null` for `manual`-origin suppressions

## Release timing

These endpoints are in beta and gated behind a server-side feature flag: a team without access receives **404 on every suppression endpoint**. Merging is safe, but worth a deliberate decision on whether this ships in the next release or waits for wider flag rollout, since otherwise a documented SDK method returns 404 for most users.

## Verification

```
dotnet build   -> 0 Errors
dotnet test    -> 173 passed (158 Resend.Tests + 11 Webhooks + 4 FluentEmail), 0 failed
```
Run on the **.NET 8** SDK to match CI (`dotnet-version: 8.0.x`) and the `net8.0` target. Worth knowing for anyone reproducing locally: on a machine with only the .NET 10 runtime installed, `dotnet test` aborts outright, and forcing `DOTNET_ROLL_FORWARD=Major` yields ~61 spurious failures out of 131 on unmodified `main` — so a .NET 8 runtime is required for a meaningful run.

Tests cover all six operations plus null `source_id`, a **non-UUID** `source_id` on both the single and list shapes, and the real Postgres-style `created_at` format the API actually emits (`2026-07-24 18:30:00.123456+00`) rather than only the ISO form shown in the docs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Suppressions API support to the .NET client for add, list, get, remove, and batch operations to manage suppressed emails. Matches server behavior and edge cases.

- **New Features**
  - Methods: `SuppressionAddAsync`, `SuppressionListAsync`, `SuppressionRetrieveAsync`, `SuppressionRemoveAsync`, `SuppressionBatchAddAsync`, `SuppressionBatchRemoveAsync`.
  - `SuppressionRetrieveAsync`/`SuppressionRemoveAsync` accept an ID or an email (string). Input is URL-encoded; blank values throw `ArgumentException`.
  - Separate models for single vs list: `Suppression` (has `object`) and `SuppressionSummary` (no `object`).
  - `source_id` is `string?` to allow non-UUID values; `Id` remains `Guid`.
  - Batch remove has two overloads (emails or ids). The unset field is omitted in the payload to satisfy the XOR rule.
  - Batch responses can be shorter than inputs (email dedupe; remove returns only deleted). Do not pair results to inputs by index.
  - List supports pagination and optional `origin` filter. Endpoints may return 404 for teams without the feature flag.

- **Bug Fixes**
  - Mock server: reject null/blank entries in suppression batches with 422 (not 500), matching API validation and preventing silent drops.
  - Enum JSON handling: allow aliases and throw on conflicting wire values; share wire mapping via `JsonStringEnumValue<T>` and use it for the `origin` query.

<sup>Written for commit c8bb622beca27500a50c90f7e5b96f961b7c4fc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

